### PR TITLE
Fan out per-model-gateway routing to every external-AI gateway sample

### DIFF
--- a/options-infra/ai-gateway-basic/README.md
+++ b/options-infra/ai-gateway-basic/README.md
@@ -82,6 +82,30 @@ All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-g
 
 The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
+## Advanced features
+
+The shared `per-model-gateway` orchestrator supports three opt-in features that work in any sample:
+
+### Anthropic (Claude) models on Foundry
+
+Foundry exposes Claude under `/anthropic/*` instead of `/openai/*`. When a deployment in `FOUNDRY_INSTANCES_JSON` carries `"modelFormat": "Anthropic"`, [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) automatically points that backend at `{endpoint}anthropic` while OpenAI/Cohere/DeepSeek/OpenAI-OSS deployments continue to use `{endpoint}openai`. The same gateway transparently serves both `/deployments/{name}/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape); no separate API is needed.
+
+The discovery script picks up Anthropic deployments natively — no config change required.
+
+### Chaining (APIM-to-APIM)
+
+To front another APIM gateway (one that already follows this per-model-gateway convention) instead of a Cognitive Services account, set `EXISTING_APIM_RESOURCE_IDS` alongside `EXISTING_FOUNDRY_RESOURCE_IDS`. The discovery hook enumerates the downstream APIM's catalog and writes an entry with `"isApim": true` into `FOUNDRY_INSTANCES_JSON`. The orchestrator then:
+
+- Points backends at `{endpoint}inference/openai` (the downstream's passthrough catch-all) regardless of model format — model-format split is the downstream's concern.
+- Skips the per-instance Cognitive Services RBAC role assignment (the downstream authenticates inbound via JWT, not RBAC).
+- Skips per-instance private endpoint creation in network-injected variants (the downstream APIM exposes its own endpoint).
+
+Useful for regional fan-out: one local APIM aggregates several remote APIMs, each fronting their own Foundry accounts.
+
+### Optional inbound JWT validation (`acceptedTenantIds`)
+
+By default the gateway is open — callers reach it anonymously and APIM's managed identity authenticates outbound to Foundry. Set `acceptedTenantIds` to a non-empty list of tenant IDs to require `Authorization: Bearer <token>` on every inbound call with `aud=https://cognitiveservices.azure.com` and an `iss` matching one of the configured tenants (both v1 `sts.windows.net/{tid}/` and v2 `login.microsoftonline.com/{tid}/v2.0` issuers are accepted). Defaults to `[]` for backward compatibility.
+
 ## Deployment
 
 ```bash

--- a/options-infra/ai-gateway-basic/README.md
+++ b/options-infra/ai-gateway-basic/README.md
@@ -1,6 +1,8 @@
 # Option: AI Gateway (External APIM) with Foundry Basic
 
-This deployment creates a Foundry Basic environment with an **external Azure API Management (APIM) Basic v2** instance acting as an AI Gateway. The goal is to allow **Foundry Agent Service** to use models from APIM, which proxies requests to an external Azure OpenAI resource.
+This deployment creates a Foundry Basic environment with an **external Azure API Management (APIM) Basic v2** instance acting as an AI Gateway. The goal is to allow **Foundry Agent Service** to use models from APIM, which proxies requests to **one or more** external Foundry / Azure OpenAI resources with **per-model smart routing**.
+
+Built on the shared [`modules/apim/per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) orchestrator — every backing model gets its own APIM backend + PAYG pool, and a reusable [`per-model-routing`](../modules/apim/per-model-routing-fragment.xml) policy fragment dispatches each inbound request to the right pool.
 
 ## Architecture Overview
 
@@ -9,60 +11,46 @@ This deployment creates a Foundry Basic environment with an **external Azure API
 │                                    This Deployment                                        │
 │                                                                                           │
 │  ┌──────────────────────────────────────────────────────────────────┐                     │
-│  │                      AI Foundry                                  │                     │
-│  │  ┌─────────────────────────────────────────────────────────────┐ │                     │
-│  │  │  Project(s) with Capability Hosts                           │ │                     │
-│  │  │  NO Capability Hosts / NO Agent Subnet                      │ │                     │
-│  │  │                                                             │ │                     │
-│  │  │  Agent Service (Public traffic, No VNET)   ─────────────────┼─┼──┐                  │
-│  │  └─────────────────────────────────────────────────────────────┘ │  │                  │
-│  └──────────────────────────────────────────────────────────────────┘  │                  │
-│                                                                        │                  │
-│                                                                        ▼                  │
-│                                              ┌─────────────────────────────────────────┐  │
-│                                              │   Azure API Management (External)       │  │
-│                                              │   - AI Gateway                          │  │
-│                                              │   - Public IP                           │  │
-│                                              │   - Static Model Definitions            │  │
-│                                              │   - Rate Limiting / Policies            │  │
-│                                              └──────────────────┬──────────────────────┘  │
-│                                                                 │                         │
-│  ┌──────────────────────────────────────────────────────────────┼───────────────────────┐ │
-│  │                    Supporting Services                       │                       │ │
-│  │  VNet │ Key Vault │ Log Analytics │ App Insights │ Private DNS                       │ │
-│  └──────────────────────────────────────────────────────────────┼───────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┼─────────────────────────┘
-                                                                  │
-                                          (Public Internet)       │
-                                                                  ▼
-                                ┌──────────────────────────────────────────────┐
-                                │    External: Azure OpenAI (Landing Zone)     │
-                                │                                              │
-                                │    Models:                                   │
-                                │    - gpt-4.1-mini                            │
-                                │    - gpt-5-mini                              │
-                                │    - o3-mini                                 │
-                                └──────────────────────────────────────────────┘
+│  │                      AI Foundry Basic                            │                     │
+│  │  Project(s), public traffic, no VNet or private endpoints        │                     │
+│  └───────────────────────────────────────────────┬──────────────────┘                     │
+│                                                  │                                        │
+│                                                  ▼                                        │
+│                        ┌─────────────────────────────────────────────────────┐            │
+│                        │ Azure API Management Basicv2 (Public)               │            │
+│                        │ - Passthrough API: /inference/openai                │            │
+│                        │ - Spec-backed API: /azure                           │            │
+│                        │ - Per-model routing fragment                        │            │
+│                        │ - PAYG pools: {model-clean}-payg-pool             │            │
+│                        └──────────────────────────┬──────────────────────────┘            │
+│                                                   │                                       │
+│  Supporting Services: Key Vault │ Log Analytics │ App Insights                            │
+└───────────────────────────────────────────────────┼───────────────────────────────────────┘
+                                                    │ Public Internet
+                                                    ▼
+                             ┌──────────────────────────────────────────────┐
+                             │  1..N Foundry / Azure OpenAI instances       │
+                             │  Per-instance, per-model APIM backends       │
+                             └──────────────────────────────────────────────┘
 ```
 
 **Flow:**
-1. Foundry Agent Service calls the external APIM AI Gateway
-2. APIM proxies requests over public internet to Azure OpenAI
-3. APIM uses managed identity for authentication to Azure OpenAI
+1. Foundry Agent Service calls the public APIM AI Gateway
+2. APIM extracts the requested model and routes to that model's PAYG pool
+3. APIM uses managed identity for authentication to the selected Foundry / Azure OpenAI instance
 
 ## Deployed Resources
 
 ### Foundry
-- **Foundry account** with managed identity (or use existing)
+- **Foundry account** with managed identity
 - **Foundry project(s)** with Capability Hosts (configurable count)
+- No VNet, agent subnet, or private endpoints in this basic sample
 
 ### AI Gateway (APIM)
-- **Azure API Management** in external mode (public IP)
-- Pre-configured static model definitions:
-  - `gpt-4.1-mini`
-  - `gpt-5-mini`
-  - `o3-mini`
-- Managed identity with Cognitive Services User role on external OpenAI
+- **Azure API Management Basicv2** in external/public mode
+- Per-model backends + PAYG pools synthesised from `FOUNDRY_INSTANCES_JSON`
+- Passthrough `/inference/openai` API and spec-backed `/azure` API
+- Managed identity with Cognitive Services User role on every backing instance
 
 ### Monitoring
 - **Log Analytics Workspace**
@@ -70,21 +58,34 @@ This deployment creates a Foundry Basic environment with an **external Azure API
 
 ## Prerequisites
 
-Set the following environment variables before deployment:
+Set the backing Foundry / Azure AI Services instances before deployment:
 
 ```bash
-export OPENAI_API_BASE="https://your-landing-zone-openai.openai.azure.com"
-export OPENAI_RESOURCE_ID="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<openai-name>"
+export EXISTING_FOUNDRY_RESOURCE_IDS="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-1>,/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-2>"
 ```
 
+`EXISTING_FOUNDRY_RESOURCE_IDS` is the preferred comma-separated, multi-instance form. For backwards compatibility, the discovery hook also accepts `EXISTING_FOUNDRY_RESOURCE_ID` or legacy `OPENAI_RESOURCE_ID` for a single instance.
+
+The `azure.yaml` `preprovision` hook runs [`preprovision-list-foundry-models.sh`](../scripts/preprovision-list-foundry-models.sh) / `.ps1`, calls ARM (`az cognitiveservices account deployment list`) to enumerate model deployments on every instance, and writes `FOUNDRY_INSTANCES_JSON`. `main.bicepparam` reads that JSON into the `foundryInstances` parameter using the [`foundryInstanceType[]`](../modules/apim/advanced/types.bicep) shape. Deployment fails fast with a clear error when no instances are configured.
+
 ### Optional Parameters
-- `OPENAI_LOCATION` - Location of the OpenAI resource (defaults to deployment location)
 - `PROJECTS_COUNT` - Number of Foundry projects to create (default: 1)
+
+## Per-model smart routing
+
+All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) for APIM orchestration:
+
+- [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) creates one APIM backend per `(instance, model)`, so a throttled deployment only disables that backend while sibling deployments continue serving traffic.
+- One PAYG backend pool is created per model, named `{model-clean}-payg-pool` after removing `.` and `-` from the model name; all instances serving that model join the same pool for APIM load balancing.
+- The shared [`per-model-routing`](../modules/apim/per-model-routing-fragment.xml) policy fragment is wired into both `/inference/openai` and `/azure`. It reads the model from `/deployments/{name}/...` or the request body's `model`, computes `model-clean`, and routes to the matching pool.
+- APIM's system-assigned managed identity is granted **Cognitive Services User** on every backing instance, including instances in other resource groups or subscriptions.
+
+The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
 ## Deployment
 
 ```bash
-cd options-infra/option_ai-gateway
+cd options-infra/ai-gateway-basic
 azd up
 ```
 
@@ -97,10 +98,19 @@ azd up
 | `FOUNDRY_NAME` | Name of the Foundry account |
 | `config_validation_result` | Validation status of the configuration |
 
-
 ## Use Cases
 
 - **Development/Testing**: Quick setup without private networking complexity
 - **Centralized AI Gateway**: Single point of control for AI model access
-- **Landing Zone integration**: Connect to shared Azure OpenAI in a hub subscription
-- **Policy enforcement**: Rate limiting, logging, and access control via APIM policies
+- **Landing Zone integration**: Connect to shared Foundry / Azure OpenAI instances
+- **Per-model routing**: Balance each model across every configured backing instance
+
+## Variants
+
+| Sample | Difference |
+|--------|------------|
+| [ai-gateway](../ai-gateway/) | Public APIM Basicv2 with private Foundry dependencies |
+| [ai-gateway-internal](../ai-gateway-internal/) | Developer SKU with internal VNet injection and per-instance upstream private endpoints |
+| [ai-gateway-pe](../ai-gateway-pe/) | Standardv2 with external VNet injection plus APIM private endpoint |
+| [ai-gateway-pe-custom](../ai-gateway-pe-custom/) | Standardv2 + PE, but provisions its own OpenAI account and test deployments |
+| [ai-gateway-premium](../ai-gateway-premium/) | Premiumv2 internal VNet, custom domain, dedicated APIM VNet |

--- a/options-infra/ai-gateway-basic/main.bicep
+++ b/options-infra/ai-gateway-basic/main.bicep
@@ -14,6 +14,9 @@ param projectsCount int = 3
 @description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON) from EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID. At least one instance is required.')
 param foundryInstances foundryInstanceType[]
 
+@description('Tenant IDs whose Entra ID tokens the gateway should accept on inbound calls. Empty (default) = no inbound JWT validation — callers reach the gateway anonymously and APIM’s managed identity authenticates to Foundry. When set, the inbound policy requires a valid bearer token with `aud=https://cognitiveservices.azure.com` issued by one of these tenants.')
+param acceptedTenantIds string[] = []
+
 var tags = {
   'created-by': 'option-ai-gateway'
   'hidden-title': 'Foundry Basic (no VNET) - APIM v2 Basic Public'
@@ -133,14 +136,20 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
     gatewayAuthenticationType: 'ProjectManagedIdentity'
     foundryInstances: foundryInstances
     staticModels: staticModels
+    acceptedTenantIds: acceptedTenantIds
   }
 }
 
 // Grant APIM's managed identity Cognitive Services User on every backing
 // Foundry instance — each instance may live in a different RG (and even a
 // different subscription) so we scope per-resourceId.
+//
+// Skip chained-APIM instances (isApim=true): they authenticate inbound
+// via JWT (the downstream's `validate-jwt` checks our MI token's tenant),
+// not via RBAC. They also typically live outside our subscription/tenant,
+// so the role assignment would fail anyway.
 module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'apim-role-${i}-${resourceToken}'
     scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
     params: {

--- a/options-infra/ai-gateway-internal/README.md
+++ b/options-infra/ai-gateway-internal/README.md
@@ -85,6 +85,30 @@ All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-g
 
 The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
+## Advanced features
+
+The shared `per-model-gateway` orchestrator supports three opt-in features that work in any sample:
+
+### Anthropic (Claude) models on Foundry
+
+Foundry exposes Claude under `/anthropic/*` instead of `/openai/*`. When a deployment in `FOUNDRY_INSTANCES_JSON` carries `"modelFormat": "Anthropic"`, [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) automatically points that backend at `{endpoint}anthropic` while OpenAI/Cohere/DeepSeek/OpenAI-OSS deployments continue to use `{endpoint}openai`. The same gateway transparently serves both `/deployments/{name}/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape); no separate API is needed.
+
+The discovery script picks up Anthropic deployments natively — no config change required.
+
+### Chaining (APIM-to-APIM)
+
+To front another APIM gateway (one that already follows this per-model-gateway convention) instead of a Cognitive Services account, set `EXISTING_APIM_RESOURCE_IDS` alongside `EXISTING_FOUNDRY_RESOURCE_IDS`. The discovery hook enumerates the downstream APIM's catalog and writes an entry with `"isApim": true` into `FOUNDRY_INSTANCES_JSON`. The orchestrator then:
+
+- Points backends at `{endpoint}inference/openai` (the downstream's passthrough catch-all) regardless of model format — model-format split is the downstream's concern.
+- Skips the per-instance Cognitive Services RBAC role assignment (the downstream authenticates inbound via JWT, not RBAC).
+- Skips per-instance private endpoint creation in network-injected variants (the downstream APIM exposes its own endpoint).
+
+Useful for regional fan-out: one local APIM aggregates several remote APIMs, each fronting their own Foundry accounts.
+
+### Optional inbound JWT validation (`acceptedTenantIds`)
+
+By default the gateway is open — callers reach it anonymously and APIM's managed identity authenticates outbound to Foundry. Set `acceptedTenantIds` to a non-empty list of tenant IDs to require `Authorization: Bearer <token>` on every inbound call with `aud=https://cognitiveservices.azure.com` and an `iss` matching one of the configured tenants (both v1 `sts.windows.net/{tid}/` and v2 `login.microsoftonline.com/{tid}/v2.0` issuers are accepted). Defaults to `[]` for backward compatibility.
+
 ## Deployment
 
 ```bash

--- a/options-infra/ai-gateway-internal/README.md
+++ b/options-infra/ai-gateway-internal/README.md
@@ -1,6 +1,6 @@
 # Option: AI Gateway (Internal APIM) with Foundry
 
-This deployment creates a Foundry environment with an **internal Azure API Management (APIM)** instance acting as an AI Gateway. The goal is to allow **Foundry Agent Service** to use models from APIM, which proxies requests to an external Azure OpenAI resource.
+This deployment creates a Foundry environment with a **Developer SKU Azure API Management (APIM)** instance in **Internal VNet injection** mode acting as an AI Gateway. It lets **Foundry Agent Service** use models from APIM, which proxies requests to **one or more** existing Foundry / Azure OpenAI instances with **per-model smart routing** through [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep).
 
 ## Architecture Overview
 
@@ -10,57 +10,38 @@ This deployment creates a Foundry environment with an **internal Azure API Manag
 │                                                                                           │
 │  ┌──────────────────────────────────────────────────────────────────┐                     │
 │  │                      AI Foundry                                  │                     │
-│  │  ┌─────────────────────────────────────────────────────────────┐ │                     │
-│  │  │  Project(s) with Capability Hosts                           │ │                     │
-│  │  │                                                             │ │                     │
-│  │  │  Agent Service ─── Vnet injection ──────────────────────────┼─┼──┐                  │
-│  │  └─────────────────────────────────────────────────────────────┘ │  │                  │
+│  │  Project(s) with Capability Hosts and private dependencies       │                     │
+│  │  Agent Service ─── VNet injection ───────────────────────────────┼──┐                  │
 │  └──────────────────────────────────────────────────────────────────┘  │                  │
-│                                                                        │                  │
 │                                                                        ▼                  │
-│                                              ┌─────────────────────────────────────────┐  │
-│                                              │   Azure API Management (Internal)       │  │
-│                                              │   - Vnet injected                       │  │
-│                                              │   - AI Gateway                          │  │
-│                                              │   - Static Model Definitions            │  │
-│                                              │   - Load Balancing (future)             │  │
-│                                              │   - Rate Limiting / Policies            │  │
-│                                              └──────────────────┬──────────────────────┘  │
-│                                                                 │                         │
-│  ┌──────────────────────────────────────────────────────────────┼───────────────────────┐ │
-│  │                    Supporting Services                       │                       │ │
-│  │  VNet │ Key Vault │ Log Analytics │ App Insights │ Private DNS │ Private Endpoints   │ │
-│  └──────────────────────────────────────────────────────────────┼───────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┼─────────────────────────┘
-                                                                  │
-                                           (Private Endpoint)     │
-                                                                  ▼
-                                ┌──────────────────────────────────────────────┐
-                                │    External: Azure OpenAI (Landing Zone)     │
-                                │                                              │
-                                │    Models:                                   │
-                                │    - gpt-4.1-mini                            │
-                                │    - gpt-5-mini                              │
-                                │    - o3-mini                                 │
-                                └──────────────────────────────────────────────┘
+│                        ┌─────────────────────────────────────────────────────┐            │
+│                        │ Azure API Management Developer (Internal VNet)      │            │
+│                        │ - No public endpoint                                │            │
+│                        │ - /inference/openai + /azure APIs                  │            │
+│                        │ - Per-model PAYG pools                              │            │
+│                        └──────────────────────────┬──────────────────────────┘            │
+│                                                   │                                       │
+│  VNet │ Private DNS │ Key Vault │ Storage │ Cosmos │ AI Search │ MCP/OpenAPI services      │
+└───────────────────────────────────────────────────┼───────────────────────────────────────┘
+                                                    │ Private endpoints (one per instance)
+                                                    ▼
+                             ┌──────────────────────────────────────────────┐
+                             │  1..N Foundry / Azure OpenAI instances       │
+                             │  Per-instance, per-model APIM backends       │
+                             └──────────────────────────────────────────────┘
 ```
 
 **Flow:**
 1. Foundry Agent Service calls the internal APIM AI Gateway
-2. APIM proxies requests via private endpoint to external Azure OpenAI
-3. All traffic stays within private network (no public internet)
+2. APIM extracts the requested model and routes to that model's PAYG pool
+3. APIM reaches each backing instance through a private endpoint in the local VNet
 
 ## Deployed Resources
 
 ### Networking
-- **Virtual Network** with subnets for:
-  - Private Endpoints
-  - APIM (internal mode)
-  - Agent services
-- **Private DNS Zones** for:
-  - Azure OpenAI (`privatelink.openai.azure.com`)
-  - Key Vault, Storage, Cosmos DB, AI Search
-- **Private Endpoint** to external Azure OpenAI resource
+- **Virtual Network** with subnets for private endpoints, APIM internal injection, and agent services
+- **Private DNS Zones** for Azure OpenAI (`privatelink.openai.azure.com`), Key Vault, Storage, Cosmos DB, and AI Search
+- **One private endpoint per backing Foundry / Azure OpenAI instance** so internal APIM can reach upstream models
 
 ### Foundry
 - **Foundry account** with managed identity
@@ -68,12 +49,11 @@ This deployment creates a Foundry environment with an **internal Azure API Manag
 - **AI Dependencies**: Storage, Cosmos DB, AI Search with private endpoints
 
 ### AI Gateway (APIM)
-- **Azure API Management** in internal (VNet-injected) mode
-- Pre-configured static model definitions:
-  - `gpt-4.1-mini`
-  - `gpt-5-mini`
-  - `o3-mini`
-- Managed identity with Cognitive Services User role on external OpenAI
+- **Azure API Management Developer SKU** in internal VNet-injected mode
+- Per-model backends + PAYG pools synthesised from `FOUNDRY_INSTANCES_JSON`
+- Passthrough `/inference/openai` API and spec-backed `/azure` API
+- Managed identity with Cognitive Services User role on every backing instance
+- Optional `apiServices` entries for private MCP/OpenAPI services are exposed through APIM and private DNS
 
 ### Monitoring
 - **Log Analytics Workspace**
@@ -81,21 +61,34 @@ This deployment creates a Foundry environment with an **internal Azure API Manag
 
 ## Prerequisites
 
-Set the following environment variables before deployment:
+Set the backing Foundry / Azure AI Services instances before deployment:
 
 ```bash
-export OPENAI_API_BASE="https://your-landing-zone-openai.openai.azure.com"
-export OPENAI_RESOURCE_ID="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<openai-name>"
+export EXISTING_FOUNDRY_RESOURCE_IDS="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-1>,/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-2>"
 ```
 
+`EXISTING_FOUNDRY_RESOURCE_IDS` is the preferred comma-separated, multi-instance form. For backwards compatibility, the discovery hook also accepts `EXISTING_FOUNDRY_RESOURCE_ID` or legacy `OPENAI_RESOURCE_ID` for a single instance.
+
+The `azure.yaml` `preprovision` hook runs [`preprovision-list-foundry-models.sh`](../scripts/preprovision-list-foundry-models.sh) / `.ps1`, calls ARM (`az cognitiveservices account deployment list`) to enumerate model deployments on every instance, and writes `FOUNDRY_INSTANCES_JSON`. `main.bicepparam` reads that JSON into the `foundryInstances` parameter using the [`foundryInstanceType[]`](../modules/apim/advanced/types.bicep) shape. Deployment fails fast with a clear error when no instances are configured.
+
 ### Optional Parameters
-- `OPENAI_LOCATION` - Location of the OpenAI resource (defaults to deployment location)
 - `PROJECTS_COUNT` - Number of Foundry projects to create (default: 1)
+
+## Per-model smart routing
+
+All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) for APIM orchestration:
+
+- [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) creates one APIM backend per `(instance, model)`, so a throttled deployment only disables that backend while sibling deployments continue serving traffic.
+- One PAYG backend pool is created per model, named `{model-clean}-payg-pool` after removing `.` and `-` from the model name; all instances serving that model join the same pool for APIM load balancing.
+- The shared [`per-model-routing`](../modules/apim/per-model-routing-fragment.xml) policy fragment is wired into both `/inference/openai` and `/azure`. It reads the model from `/deployments/{name}/...` or the request body's `model`, computes `model-clean`, and routes to the matching pool.
+- APIM's system-assigned managed identity is granted **Cognitive Services User** on every backing instance, including instances in other resource groups or subscriptions.
+
+The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
 ## Deployment
 
 ```bash
-cd options-infra/option_ai-gateway-internal
+cd options-infra/ai-gateway-internal
 azd up
 ```
 
@@ -108,17 +101,19 @@ azd up
 | `FOUNDRY_NAME` | Name of the Foundry account |
 | `config_validation_result` | Validation status of the configuration |
 
-## Key Differences from `option_ai-gateway`
-
-| Feature | `option_ai-gateway` | `option_ai-gateway-internal` |
-|---------|---------------------|------------------------------|
-| APIM Mode | External (public IP) | Internal (VNet only) |
-| OpenAI Access | Via public endpoint | Via private endpoint |
-| Network Security | Public accessible | Fully private |
-
 ## Use Cases
 
-- **Enterprise/Regulated environments**: All AI traffic stays within private network
+- **Enterprise/Regulated environments**: APIM has no public endpoint
 - **Centralized AI Gateway**: Single point of control for AI model access
-- **Landing Zone integration**: Connect to shared Azure OpenAI in a hub subscription
-- **Policy enforcement**: Rate limiting, logging, and access control via APIM policies
+- **Landing Zone integration**: Connect privately to shared Foundry / Azure OpenAI instances
+- **Private tool integration**: Publish MCP/OpenAPI services alongside model APIs
+
+## Variants
+
+| Sample | Difference |
+|--------|------------|
+| [ai-gateway-basic](../ai-gateway-basic/) | Public APIM Basicv2, no VNet at all |
+| [ai-gateway](../ai-gateway/) | Public APIM Basicv2 with private Foundry dependencies |
+| [ai-gateway-pe](../ai-gateway-pe/) | Standardv2 with external VNet injection plus APIM private endpoint |
+| [ai-gateway-pe-custom](../ai-gateway-pe-custom/) | Standardv2 + PE, but provisions its own OpenAI account and test deployments |
+| [ai-gateway-premium](../ai-gateway-premium/) | Premiumv2 internal VNet, custom domain, dedicated APIM VNet |

--- a/options-infra/ai-gateway-internal/azure.yaml
+++ b/options-infra/ai-gateway-internal/azure.yaml
@@ -7,6 +7,21 @@ infra:
   module: main
 
 hooks:
+  preprovision:
+    windows:
+      shell: pwsh
+      run: |
+        & '../scripts/preprovision-list-foundry-models.ps1'
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      interactive: false
+      continueOnError: false
+    posix:
+      shell: sh
+      run: |
+        sh ../scripts/preprovision-list-foundry-models.sh
+      interactive: false
+      continueOnError: false
+
   postprovision:
     windows:
       shell: pwsh

--- a/options-infra/ai-gateway-internal/main.bicep
+++ b/options-infra/ai-gateway-internal/main.bicep
@@ -17,6 +17,9 @@ param apiServices apiType[] = []
 @description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON) from EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID. At least one instance is required.')
 param foundryInstances foundryInstanceType[]
 
+@description('Tenant IDs whose Entra ID tokens the gateway should accept on inbound calls. Empty (default) = no inbound JWT validation — callers reach the gateway anonymously and APIM\'s managed identity authenticates to Foundry. When set, the inbound policy requires a valid bearer token with `aud=https://cognitiveservices.azure.com` issued by one of these tenants.')
+param acceptedTenantIds string[] = []
+
 var valid_config = empty(foundryInstances)
   ? fail('No Foundry instances configured. Set EXISTING_FOUNDRY_RESOURCE_IDS (or OPENAI_RESOURCE_ID) and run the `preprovision-list-foundry-models` hook so FOUNDRY_INSTANCES_JSON is populated.')
   : true
@@ -88,8 +91,12 @@ module ai_dependencies '../modules/ai/ai-dependencies-with-dns.bicep' = {
 // Private endpoint per backing Foundry instance (each may live in a different
 // subscription/RG). The PE goes into THIS deployment's VNet so the internal
 // APIM can reach the upstream models.
+//
+// Skip chained-APIM instances (isApim=true) — they're not Cognitive Services
+// accounts, so no PE is needed; the downstream APIM exposes its own public or
+// private endpoint that our gateway calls over the network.
 module openai_private_endpoints '../modules/networking/ai-pe-dns.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'openai-pe-${i}-${resourceToken}'
     params: {
       tags: tags
@@ -193,6 +200,7 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
     gatewayAuthenticationType: 'ProjectManagedIdentity'
     foundryInstances: foundryInstances
     staticModels: staticModels
+    acceptedTenantIds: acceptedTenantIds
     // Internal VNet injection - APIM lives inside the VNet, no public network access
     apimSku: 'Developer'
     virtualNetworkType: 'Internal'
@@ -202,8 +210,12 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
 
 // Grant APIM's managed identity Cognitive Services User on every backing
 // Foundry instance — each instance may live in a different RG/subscription.
+//
+// Skip chained-APIM instances (isApim=true): they authenticate inbound
+// via JWT (the downstream's `validate-jwt` checks our MI token's tenant),
+// not via RBAC.
 module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'apim-role-${i}-${resourceToken}'
     scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
     params: {

--- a/options-infra/ai-gateway-internal/main.bicep
+++ b/options-infra/ai-gateway-internal/main.bicep
@@ -7,16 +7,18 @@
 targetScope = 'resourceGroup'
 
 import { apiType } from '../modules/apps/apps-private-link.bicep'
+import { foundryInstanceType } from '../modules/apim/advanced/types.bicep'
+import { ModelType } from '../modules/ai/connection-apim-gateway.bicep'
 
 param location string = resourceGroup().location
-param openAiApiBase string
-param openAiResourceId string
-param openAiLocation string = location
 param projectsCount int = 3
-param apiServices apiType[] = [] // Array of MCP service definitions
+param apiServices apiType[] = []
 
-var valid_config = empty(openAiApiBase) || empty(openAiResourceId)
-  ? fail('OPENAI_API_BASE and OPENAI_RESOURCE_ID environment variables must be set.')
+@description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON) from EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID. At least one instance is required.')
+param foundryInstances foundryInstanceType[]
+
+var valid_config = empty(foundryInstances)
+  ? fail('No Foundry instances configured. Set EXISTING_FOUNDRY_RESOURCE_IDS (or OPENAI_RESOURCE_ID) and run the `preprovision-list-foundry-models` hook so FOUNDRY_INSTANCES_JSON is populated.')
   : true
 
 var tags = {
@@ -27,10 +29,27 @@ var tags = {
 }
 
 var resourceToken = toLower(uniqueString(resourceGroup().id, location))
-var openAiParts = split(openAiResourceId, '/')
-var openAiName = last(openAiParts)
-var openAiSubscriptionId = openAiParts[2]
-var openAiResourceGroupName = openAiParts[4]
+
+// Dedupe model deployments across all instances → ModelType[] for the Foundry
+// connection's portal model picker.
+var allDeployments = flatten(map(foundryInstances, inst => inst.deployments))
+var dedupedDeployments = reduce(
+  allDeployments,
+  [],
+  (acc, d) => contains(map(acc, x => x.modelName), d.modelName) ? acc : concat(acc, [d])
+)
+var staticModels ModelType[] = [
+  for d in dedupedDeployments: {
+    name: d.modelName
+    properties: {
+      model: {
+        name: d.modelName
+        version: d.?modelVersion ?? '2025-01-01-preview'
+        format: d.?modelFormat ?? 'OpenAI'
+      }
+    }
+  }
+]
 
 module foundry_identity '../modules/iam/identity.bicep' = {
   name: 'foundry-identity-deployment'
@@ -66,20 +85,24 @@ module ai_dependencies '../modules/ai/ai-dependencies-with-dns.bicep' = {
   }
 }
 
-// Private endpoint for external OpenAI
-module openai_private_endpoint '../modules/networking/ai-pe-dns.bicep' = {
-  name: 'openai-private-endpoint-and-dns-deployment'
-  params: {
-    tags: tags
-    location: location
-    aiAccountName: openAiName
-    aiAccountNameResourceGroup: openAiResourceGroupName
-    aiAccountSubscriptionId: openAiSubscriptionId
-    peSubnetId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
-    resourceToken: resourceToken
-    existingDnsZones: ai_dependencies.outputs.DNS_ZONES
+// Private endpoint per backing Foundry instance (each may live in a different
+// subscription/RG). The PE goes into THIS deployment's VNet so the internal
+// APIM can reach the upstream models.
+module openai_private_endpoints '../modules/networking/ai-pe-dns.bicep' = [
+  for (instance, i) in foundryInstances: {
+    name: 'openai-pe-${i}-${resourceToken}'
+    params: {
+      tags: tags
+      location: location
+      aiAccountName: last(split(instance.resourceId, '/'))
+      aiAccountNameResourceGroup: split(instance.resourceId, '/')[4]
+      aiAccountSubscriptionId: split(instance.resourceId, '/')[2]
+      peSubnetId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
+      resourceToken: '${resourceToken}-${i}'
+      existingDnsZones: ai_dependencies.outputs.DNS_ZONES
+    }
   }
-}
+]
 
 // --------------------------------------------------------------------------------------------------------------
 // -- Log Analytics Workspace and App Insights ------------------------------------------------------------------
@@ -156,80 +179,40 @@ module projects '../modules/ai/ai-project-with-caphost.bicep' = [
   }
 ]
 
-module ai_gateway '../modules/apim/ai-gateway-internal.bicep' = {
+module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
   name: 'ai-gateway-deployment-${resourceToken}'
   params: {
     tags: tags
     location: location
     resourceToken: resourceToken
     aiFoundryName: foundry.outputs.FOUNDRY_NAME
-    subnetResourceId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.apimSubnet.resourceId
-    logAnalyticsWorkspaceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
-    appInsightsId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
-    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
     aiFoundryProjectNames: [for i in range(1, projectsCount): projects[i - 1].outputs.FOUNDRY_PROJECT_NAME]
-    staticModels: [
-      {
-        name: 'gpt-4.1-mini'
-        properties: {
-          model: {
-            name: 'gpt-4.1-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-4o'
-        properties: {
-          model: {
-            name: 'gpt-4o'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-5-mini'
-        properties: {
-          model: {
-            name: 'gpt-5-mini'
-            version: '2025-04-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'o3-mini'
-        properties: {
-          model: {
-            name: 'o3-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-    ]
-    aiServicesConfig: [
-      {
-        name: openAiName
-        resourceId: openAiResourceId
-        endpoint: openAiApiBase
-        location: openAiLocation
-      }
-    ]
+    logAnalyticsWorkspaceResourceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
+    appInsightsResourceId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
+    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
+    gatewayAuthenticationType: 'ProjectManagedIdentity'
+    foundryInstances: foundryInstances
+    staticModels: staticModels
+    // Internal VNet injection - APIM lives inside the VNet, no public network access
+    apimSku: 'Developer'
+    virtualNetworkType: 'Internal'
+    subnetResourceId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.apimSubnet.resourceId
   }
 }
 
-module apim_role_assignment '../modules/iam/role-assignment-cognitiveServices.bicep' = {
-  name: 'apim-role-assignment-deployment-${resourceToken}'
-  scope: resourceGroup(openAiSubscriptionId, openAiResourceGroupName)
-  params: {
-    accountName: openAiName
-    principalId: ai_gateway.outputs.apimPrincipalId
-    roleName: 'Cognitive Services User'
+// Grant APIM's managed identity Cognitive Services User on every backing
+// Foundry instance — each instance may live in a different RG/subscription.
+module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
+  for (instance, i) in foundryInstances: {
+    name: 'apim-role-${i}-${resourceToken}'
+    scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
+    params: {
+      accountName: last(split(instance.resourceId, '/'))
+      principalId: ai_gateway.outputs.apimPrincipalId
+      roleName: 'Cognitive Services User'
+    }
   }
-}
+]
 
 module dashboard_setup '../modules/dashboard/dashboard-setup.bicep' = {
   name: 'dashboard-setup-deployment-${resourceToken}'

--- a/options-infra/ai-gateway-internal/main.bicepparam
+++ b/options-infra/ai-gateway-internal/main.bicepparam
@@ -1,11 +1,10 @@
 using 'main.bicep'
 
-// Parameters for the main Bicep template
-param openAiApiBase = readEnvironmentVariable('OPENAI_API_BASE', '')
-param openAiResourceId = readEnvironmentVariable('OPENAI_RESOURCE_ID', '')
-
-var openAiLocationValue = readEnvironmentVariable('OPENAI_LOCATION', '')
-param openAiLocation = empty(openAiLocationValue) ? null : openAiLocationValue
+// Foundry instances discovered by the `preprovision-list-foundry-models` hook
+// (reads EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID and writes
+// FOUNDRY_INSTANCES_JSON). At least one instance with at least one deployment
+// is required — main.bicep fails the deployment otherwise.
+param foundryInstances = json(readEnvironmentVariable('FOUNDRY_INSTANCES_JSON', '[]'))
 
 var projectsCountValue = readEnvironmentVariable('PROJECTS_COUNT','')
 param projectsCount = empty(projectsCountValue) ? null : int(projectsCountValue)

--- a/options-infra/ai-gateway-pe-custom/README.md
+++ b/options-infra/ai-gateway-pe-custom/README.md
@@ -1,6 +1,6 @@
-# Option: AI Gateway (APIM Standard v2) with Foundry
+# Option: AI Gateway (APIM Standard v2 + Private Endpoint) with In-Deployment OpenAI
 
-This deployment creates a Foundry environment with an **Azure API Management (APIM) v2 Standard sku with private endpoint** instance acting as an AI Gateway. The goal is to allow **Foundry Agent Service** to use models from APIM, which proxies requests to an external Azure OpenAI resource.
+This deployment creates a Foundry environment with an **Azure API Management (APIM) Standardv2** instance in **External VNet injection** mode plus an APIM private endpoint. It uses [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) for **per-model smart routing**; instead of external fan-out, this sample provisions one local Azure OpenAI account and synthesizes the same gateway instance shape from it.
 
 ## Architecture Overview
 
@@ -10,69 +10,52 @@ This deployment creates a Foundry environment with an **Azure API Management (AP
 │                                                                                           │
 │  ┌──────────────────────────────────────────────────────────────────┐                     │
 │  │                      AI Foundry                                  │                     │
-│  │  ┌─────────────────────────────────────────────────────────────┐ │                     │
-│  │  │  Project(s) with Capability Hosts                           │ │                     │
-│  │  │                                                             │ │                     │
-│  │  │  Agent Service ─────────────────────────────────────────────┼─┼──┐                  │
-│  │  └─────────────────────────────────────────────────────────────┘ │  │                  │
-│  └──────────────────────────────────────────────────────────────────┘  │                  │
-│                                                                        │                  │
-│                                                                        ▼                  │
-│                                              ┌─────────────────────────────────────────┐  │
-│                                              │  Azure API Management (Private Endpoint)│  │
-│                                              │  - AI Gateway                           │  │
-│                                              │  - Static Model Definitions             │  │
-│                                              │  - Load Balancing (future)              │  │
-│                                              │  - Rate Limiting / Policies             │  │
-│                                              └──────────────────┬──────────────────────┘  │
-│                                                                 │                         │
-│  ┌──────────────────────────────────────────────────────────────┼───────────────────────┐ │
-│  │                    Supporting Services                       │                       │ │
-│  │  VNet │ Key Vault │ Log Analytics │ App Insights │ Private DNS │ Private Endpoints   │ │
-│  └──────────────────────────────────────────────────────────────┼───────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┼─────────────────────────┘
-                                                                  │
-                                           (Private Endpoint)     │
-                                                                  ▼
-                                ┌──────────────────────────────────────────────┐
-                                │    Azure OpenAI (Landing Zone)               │
-                                │                                              │
-                                │    Models:                                   │
-                                │    - gpt-4.1-mini                            │
-                                │    - gpt-5-mini                              │
-                                │    - o3-mini                                 │
-                                └──────────────────────────────────────────────┘
+│  │  Project(s) with Capability Hosts and private dependencies       │                     │
+│  └───────────────────────────────────────────────┬──────────────────┘                     │
+│                                                  │ APIM private endpoint                  │
+│                                                  ▼                                        │
+│                        ┌─────────────────────────────────────────────────────┐            │
+│                        │ Azure API Management Standardv2 (External + PE)     │            │
+│                        │ - /inference/openai + /azure APIs                  │            │
+│                        │ - Per-model routing fragment                        │            │
+│                        │ - PAYG pools for test-gpt-4.1 and test-gpt-5.2      │            │
+│                        └──────────────────────────┬──────────────────────────┘            │
+│                                                   │                                       │
+│  VNet │ Private DNS │ Key Vault │ Storage │ Cosmos │ AI Search │ MCP/OpenAPI services      │
+└───────────────────────────────────────────────────┼───────────────────────────────────────┘
+                                                    │ Single private endpoint
+                                                    ▼
+                             ┌──────────────────────────────────────────────┐
+                             │  In-deployment Azure OpenAI account          │
+                             │  Deployments: test-gpt-4.1, test-gpt-5.2    │
+                             └──────────────────────────────────────────────┘
 ```
 
 **Flow:**
-1. Foundry Agent Service calls the internal APIM AI Gateway
-2. APIM proxies requests via private endpoint to external Azure OpenAI
-3. All traffic stays within private network (no public internet)
+1. Foundry Agent Service calls APIM through the APIM private endpoint
+2. APIM extracts the requested model and routes to that model's PAYG pool
+3. APIM reaches the locally provisioned Azure OpenAI account through a private endpoint
 
 ## Deployed Resources
 
 ### Networking
-- **Virtual Network** with subnets for:
-  - Private Endpoints
-  - APIM (internal mode)
-  - Agent services
-- **Private DNS Zones** for:
-  - Azure OpenAI (`privatelink.openai.azure.com`)
-  - Key Vault, Storage, Cosmos DB, AI Search
-- **Private Endpoint** to external Azure OpenAI resource
+- **Virtual Network** with subnets for private endpoints, APIM external injection, and agent services
+- **Private DNS Zones** for APIM (`privatelink.azure-api.net`), Azure OpenAI (`privatelink.openai.azure.com`), Key Vault, Storage, Cosmos DB, and AI Search
+- **APIM private endpoint**; `APIM_PUBLIC_ENABLED` controls whether public access remains enabled after PE attachment
+- **Single private endpoint** to the in-deployment Azure OpenAI account
 
 ### Foundry
 - **Foundry account** with managed identity
 - **Foundry project(s)** with Capability Hosts (configurable count)
 - **AI Dependencies**: Storage, Cosmos DB, AI Search with private endpoints
+- **Azure OpenAI account** created in-deployment with `test-gpt-4.1` and `test-gpt-5.2` deployments
 
 ### AI Gateway (APIM)
-- **Azure API Management** in internal (VNet-injected) mode
-- Pre-configured static model definitions:
-  - `gpt-4.1-mini`
-  - `gpt-5-mini`
-  - `o3-mini`
-- Managed identity with Cognitive Services User role on external OpenAI
+- **Azure API Management Standardv2** in external VNet-injected mode with private endpoint
+- Per-model backends + PAYG pools synthesised from the in-deployment OpenAI account
+- Passthrough `/inference/openai` API and spec-backed `/azure` API
+- Managed identity with Cognitive Services User role on the local OpenAI account
+- Optional `apiServices` entries for private MCP/OpenAPI services are exposed through APIM and private DNS
 
 ### Monitoring
 - **Log Analytics Workspace**
@@ -80,14 +63,27 @@ This deployment creates a Foundry environment with an **Azure API Management (AP
 
 ## Prerequisites
 
+No external Foundry / Azure OpenAI resource is required. This sample provisions its own Azure OpenAI account in-deployment with `test-gpt-4.1` and `test-gpt-5.2`, then routes to it through per-model PAYG pools. The deployment synthesizes a single-instance `foundryInstances[]` value from that local account.
+
 ### Optional Parameters
-- `OPENAI_LOCATION` - Location of the OpenAI resource (defaults to deployment location)
 - `PROJECTS_COUNT` - Number of Foundry projects to create (default: 1)
+- `APIM_PUBLIC_ENABLED` - Set to `true` to keep APIM public access enabled after the private endpoint is attached (default: `false`)
+
+## Per-model smart routing
+
+All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) for APIM orchestration:
+
+- [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) creates one APIM backend per `(instance, model)`, so a throttled deployment only disables that backend while sibling deployments continue serving traffic.
+- One PAYG backend pool is created per model, named `{model-clean}-payg-pool` after removing `.` and `-` from the model name; all instances serving that model join the same pool for APIM load balancing.
+- The shared [`per-model-routing`](../modules/apim/per-model-routing-fragment.xml) policy fragment is wired into both `/inference/openai` and `/azure`. It reads the model from `/deployments/{name}/...` or the request body's `model`, computes `model-clean`, and routes to the matching pool.
+- APIM's system-assigned managed identity is granted **Cognitive Services User** on every backing instance, including instances in other resource groups or subscriptions.
+
+The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from the synthesized in-deployment OpenAI instance.
 
 ## Deployment
 
 ```bash
-cd options-infra/option_ai-gateway-internal
+cd options-infra/ai-gateway-pe-custom
 azd up
 ```
 
@@ -100,17 +96,19 @@ azd up
 | `FOUNDRY_NAME` | Name of the Foundry account |
 | `config_validation_result` | Validation status of the configuration |
 
-## Key Differences from `option_ai-gateway`
-
-| Feature | `option_ai-gateway` | `option_ai-gateway-internal` |
-|---------|---------------------|------------------------------|
-| APIM Mode | External (public IP) | Internal (VNet only) |
-| OpenAI Access | Via public endpoint | Via private endpoint |
-| Network Security | Public accessible | Fully private |
-
 ## Use Cases
 
-- **Enterprise/Regulated environments**: All AI traffic stays within private network
-- **Centralized AI Gateway**: Single point of control for AI model access
-- **Landing Zone integration**: Connect to shared Azure OpenAI in a hub subscription
-- **Policy enforcement**: Rate limiting, logging, and access control via APIM policies
+- **Self-contained testing**: Provision APIM and a test OpenAI account together
+- **Private APIM access**: Use Standardv2 with a private endpoint while retaining External VNet injection
+- **Per-model routing validation**: Exercise routing pools without external resource prerequisites
+- **Private tool integration**: Publish MCP/OpenAPI services alongside model APIs
+
+## Variants
+
+| Sample | Difference |
+|--------|------------|
+| [ai-gateway-basic](../ai-gateway-basic/) | Public APIM Basicv2, no VNet at all |
+| [ai-gateway](../ai-gateway/) | Public APIM Basicv2 with private Foundry dependencies |
+| [ai-gateway-internal](../ai-gateway-internal/) | Developer SKU with internal VNet injection and per-instance upstream private endpoints |
+| [ai-gateway-pe](../ai-gateway-pe/) | Standardv2 with external VNet injection plus APIM private endpoint and external Foundry fan-out |
+| [ai-gateway-premium](../ai-gateway-premium/) | Premiumv2 internal VNet, custom domain, dedicated APIM VNet |

--- a/options-infra/ai-gateway-pe-custom/README.md
+++ b/options-infra/ai-gateway-pe-custom/README.md
@@ -80,6 +80,18 @@ All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-g
 
 The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from the synthesized in-deployment OpenAI instance.
 
+## Advanced features
+
+### Anthropic (Claude) models
+
+If you add an Anthropic-format deployment to `openAiDeploymentSpecs` (e.g. `{ name: 'claude-haiku-4-5', format: 'Anthropic', ... }`), [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) automatically routes that backend at `{endpoint}anthropic` instead of `{endpoint}openai`. The same gateway transparently serves both `/deployments/{name}/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape).
+
+### Optional inbound JWT validation (`acceptedTenantIds`)
+
+By default the gateway is open — callers reach it anonymously and APIM's managed identity authenticates outbound to Foundry. Set `acceptedTenantIds` to a non-empty list of tenant IDs to require `Authorization: Bearer <token>` on every inbound call with `aud=https://cognitiveservices.azure.com` and an `iss` matching one of the configured tenants (both v1 `sts.windows.net/{tid}/` and v2 `login.microsoftonline.com/{tid}/v2.0` issuers are accepted). Defaults to `[]` for backward compatibility.
+
+> Note: APIM-to-APIM chaining is not available in this sample because `foundryInstances` is synthesized locally from the in-deployment OpenAI account rather than discovered via `EXISTING_FOUNDRY_RESOURCE_IDS`. Use any other gateway variant for chaining.
+
 ## Deployment
 
 ```bash

--- a/options-infra/ai-gateway-pe-custom/main.bicep
+++ b/options-infra/ai-gateway-pe-custom/main.bicep
@@ -16,6 +16,9 @@ param apiServices apiType[] = []
 param apimPublicEnabled bool = false
 param openAiLocation string = resourceGroup().location
 
+@description('Tenant IDs whose Entra ID tokens the gateway should accept on inbound calls. Empty (default) = no inbound JWT validation — callers reach the gateway anonymously and APIM\'s managed identity authenticates to Foundry. When set, the inbound policy requires a valid bearer token with `aud=https://cognitiveservices.azure.com` issued by one of these tenants.')
+param acceptedTenantIds string[] = []
+
 var tags = {
   'created-by': 'option-ai-gateway-custom'
   'hidden-title': 'Foundry - APIM v2 Standard with PE Custom'
@@ -245,6 +248,7 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
     gatewayAuthenticationType: 'ProjectManagedIdentity'
     foundryInstances: foundryInstances
     staticModels: staticModels
+    acceptedTenantIds: acceptedTenantIds
     apimSku: 'Standardv2'
     virtualNetworkType: 'External'
     subnetResourceId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.apimv2Subnet.resourceId

--- a/options-infra/ai-gateway-pe-custom/main.bicep
+++ b/options-infra/ai-gateway-pe-custom/main.bicep
@@ -7,10 +7,12 @@
 targetScope = 'resourceGroup'
 
 import { apiType } from '../modules/apps/apps-private-link.bicep'
+import { foundryInstanceType } from '../modules/apim/advanced/types.bicep'
+import { ModelType } from '../modules/ai/connection-apim-gateway.bicep'
 
 param location string = resourceGroup().location
 param projectsCount int = 3
-param apiServices apiType[] = [] // Array of MCP service definitions
+param apiServices apiType[] = []
 param apimPublicEnabled bool = false
 param openAiLocation string = resourceGroup().location
 
@@ -21,6 +23,29 @@ var tags = {
 }
 var resourceToken = toLower(uniqueString(resourceGroup().id, location))
 
+// Model deployments to provision on the in-deployment OpenAI account.
+// The same list seeds the gateway's foundryInstances + staticModels so per-model
+// routing knows the (instance, model) pairs and the Foundry connection's
+// portal can render its model picker.
+var openAiDeploymentSpecs = [
+  {
+    name: 'test-gpt-4.1'
+    format: 'OpenAI'
+    model: 'gpt-4.1'
+    version: '2025-04-14'
+    apiVersion: '2025-01-01-preview'
+    capacity: 20
+  }
+  {
+    name: 'test-gpt-5.2'
+    format: 'OpenAI'
+    model: 'gpt-5.2'
+    version: '2025-12-11'
+    apiVersion: '2025-12-11'
+    capacity: 20
+  }
+]
+
 module openai_with_models '../modules/ai/ai-foundry.bicep' = {
   name: 'azure-openai'
   params: {
@@ -30,37 +55,57 @@ module openai_with_models '../modules/ai/ai-foundry.bicep' = {
     kind: 'OpenAI'
     publicNetworkAccess: 'Disabled'
     deployments: [
-      {
-        name: 'test-gpt-4.1'
+      for d in openAiDeploymentSpecs: {
+        name: d.name
         properties: {
           model: {
-            format: 'OpenAI'
-            name: 'gpt-4.1'
-            version: '2025-04-14'
+            format: d.format
+            name: d.model
+            version: d.version
           }
         }
         sku: {
           name: 'GlobalStandard'
-          capacity: 20
-        }
-      }
-      {
-        name: 'test-gpt-5.2'
-        properties: {
-          model: {
-            format: 'OpenAI'
-            name: 'gpt-5.2'
-            version: '2025-12-11'
-          }
-        }
-        sku: {
-          name: 'GlobalStandard'
-          capacity: 20
+          capacity: d.capacity
         }
       }
     ]
   }
 }
+
+// Synthesise the single-instance foundryInstances[] from the in-deployment
+// OpenAI account — no preprovision hook needed because the account is owned
+// by this template.
+var localFoundryDeployments = [
+  for d in openAiDeploymentSpecs: {
+    modelName: d.name
+    modelVersion: d.apiVersion
+    modelFormat: d.format
+  }
+]
+var foundryInstances foundryInstanceType[] = [
+  {
+    name: openai_with_models.outputs.FOUNDRY_NAME
+    resourceId: openai_with_models.outputs.FOUNDRY_RESOURCE_ID
+    endpoint: openai_with_models.outputs.FOUNDRY_ENDPOINT
+    location: openAiLocation
+    isPtu: false
+    deployments: localFoundryDeployments
+  }
+]
+
+var staticModels ModelType[] = [
+  for d in openAiDeploymentSpecs: {
+    name: d.name
+    properties: {
+      model: {
+        name: d.model
+        version: d.apiVersion
+        format: d.format
+      }
+    }
+  }
+]
 
 module foundry_identity '../modules/iam/identity.bicep' = {
   name: 'foundry-identity-deployment'
@@ -186,50 +231,25 @@ module projects '../modules/ai/ai-project-with-caphost.bicep' = [
   }
 ]
 
-module ai_gateway '../modules/apim/ai-gateway-pe.bicep' = {
+module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
   name: 'ai-gateway-deployment-${resourceToken}'
   params: {
     tags: tags
     location: location
-    apimPublicEnabled: apimPublicEnabled
     resourceToken: resourceToken
     aiFoundryName: foundry.outputs.FOUNDRY_NAME
+    aiFoundryProjectNames: [for i in range(1, projectsCount): projects[i - 1].outputs.FOUNDRY_PROJECT_NAME]
+    logAnalyticsWorkspaceResourceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
+    appInsightsResourceId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
+    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
+    gatewayAuthenticationType: 'ProjectManagedIdentity'
+    foundryInstances: foundryInstances
+    staticModels: staticModels
+    apimSku: 'Standardv2'
+    virtualNetworkType: 'External'
     subnetResourceId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.apimv2Subnet.resourceId
     peSubnetResourceId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
-    logAnalyticsWorkspaceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
-    appInsightsId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
-    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
-    aiFoundryProjectNames: [for i in range(1, projectsCount): projects[i - 1].outputs.FOUNDRY_PROJECT_NAME]
-    staticModels: [
-      {
-        name: 'test-gpt-4.1'
-        properties: {
-          model: {
-            name: 'gpt-4.1'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'test-gpt-5.2'
-        properties: {
-          model: {
-            format: 'OpenAI'
-            name: 'gpt-5.2'
-            version: '2025-12-11'
-          }
-        }
-      }
-    ]
-    aiServicesConfig: [
-      {
-        name: openai_with_models.outputs.FOUNDRY_NAME
-        resourceId: openai_with_models.outputs.FOUNDRY_RESOURCE_ID
-        endpoint: openai_with_models.outputs.FOUNDRY_ENDPOINT
-        location: openAiLocation
-      }
-    ]
+    publicNetworkAccess: apimPublicEnabled ? 'Enabled' : 'Disabled'
   }
 }
 

--- a/options-infra/ai-gateway-pe/README.md
+++ b/options-infra/ai-gateway-pe/README.md
@@ -87,6 +87,30 @@ All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-g
 
 The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
+## Advanced features
+
+The shared `per-model-gateway` orchestrator supports three opt-in features that work in any sample:
+
+### Anthropic (Claude) models on Foundry
+
+Foundry exposes Claude under `/anthropic/*` instead of `/openai/*`. When a deployment in `FOUNDRY_INSTANCES_JSON` carries `"modelFormat": "Anthropic"`, [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) automatically points that backend at `{endpoint}anthropic` while OpenAI/Cohere/DeepSeek/OpenAI-OSS deployments continue to use `{endpoint}openai`. The same gateway transparently serves both `/deployments/{name}/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape); no separate API is needed.
+
+The discovery script picks up Anthropic deployments natively — no config change required.
+
+### Chaining (APIM-to-APIM)
+
+To front another APIM gateway (one that already follows this per-model-gateway convention) instead of a Cognitive Services account, set `EXISTING_APIM_RESOURCE_IDS` alongside `EXISTING_FOUNDRY_RESOURCE_IDS`. The discovery hook enumerates the downstream APIM's catalog and writes an entry with `"isApim": true` into `FOUNDRY_INSTANCES_JSON`. The orchestrator then:
+
+- Points backends at `{endpoint}inference/openai` (the downstream's passthrough catch-all) regardless of model format — model-format split is the downstream's concern.
+- Skips the per-instance Cognitive Services RBAC role assignment (the downstream authenticates inbound via JWT, not RBAC).
+- Skips per-instance private endpoint creation in network-injected variants (the downstream APIM exposes its own endpoint).
+
+Useful for regional fan-out: one local APIM aggregates several remote APIMs, each fronting their own Foundry accounts.
+
+### Optional inbound JWT validation (`acceptedTenantIds`)
+
+By default the gateway is open — callers reach it anonymously and APIM's managed identity authenticates outbound to Foundry. Set `acceptedTenantIds` to a non-empty list of tenant IDs to require `Authorization: Bearer <token>` on every inbound call with `aud=https://cognitiveservices.azure.com` and an `iss` matching one of the configured tenants (both v1 `sts.windows.net/{tid}/` and v2 `login.microsoftonline.com/{tid}/v2.0` issuers are accepted). Defaults to `[]` for backward compatibility.
+
 ## Deployment
 
 ```bash

--- a/options-infra/ai-gateway-pe/README.md
+++ b/options-infra/ai-gateway-pe/README.md
@@ -1,6 +1,6 @@
-# Option: AI Gateway (APIM Standard v2) with Foundry
+# Option: AI Gateway (APIM Standard v2 + Private Endpoint) with Foundry
 
-This deployment creates a Foundry environment with an **Azure API Management (APIM) v2 Standard sku with private endpoint** instance acting as an AI Gateway. The goal is to allow **Foundry Agent Service** to use models from APIM, which proxies requests to an external Azure OpenAI resource.
+This deployment creates a Foundry environment with an **Azure API Management (APIM) Standardv2** instance in **External VNet injection** mode plus an APIM private endpoint. It lets **Foundry Agent Service** use models from APIM, which proxies requests to **one or more** existing Foundry / Azure OpenAI instances with **per-model smart routing** through [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep).
 
 ## Architecture Overview
 
@@ -10,56 +10,39 @@ This deployment creates a Foundry environment with an **Azure API Management (AP
 │                                                                                           │
 │  ┌──────────────────────────────────────────────────────────────────┐                     │
 │  │                      AI Foundry                                  │                     │
-│  │  ┌─────────────────────────────────────────────────────────────┐ │                     │
-│  │  │  Project(s) with Capability Hosts                           │ │                     │
-│  │  │                                                             │ │                     │
-│  │  │  Agent Service ─────────────────────────────────────────────┼─┼──┐                  │
-│  │  └─────────────────────────────────────────────────────────────┘ │  │                  │
-│  └──────────────────────────────────────────────────────────────────┘  │                  │
-│                                                                        │                  │
-│                                                                        ▼                  │
-│                                              ┌─────────────────────────────────────────┐  │
-│                                              │  Azure API Management (Private Endpoint)│  │
-│                                              │  - AI Gateway                           │  │
-│                                              │  - Static Model Definitions             │  │
-│                                              │  - Load Balancing (future)              │  │
-│                                              │  - Rate Limiting / Policies             │  │
-│                                              └──────────────────┬──────────────────────┘  │
-│                                                                 │                         │
-│  ┌──────────────────────────────────────────────────────────────┼───────────────────────┐ │
-│  │                    Supporting Services                       │                       │ │
-│  │  VNet │ Key Vault │ Log Analytics │ App Insights │ Private DNS │ Private Endpoints   │ │
-│  └──────────────────────────────────────────────────────────────┼───────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┼─────────────────────────┘
-                                                                  │
-                                           (Private Endpoint)     │
-                                                                  ▼
-                                ┌──────────────────────────────────────────────┐
-                                │    External: Azure OpenAI (Landing Zone)     │
-                                │                                              │
-                                │    Models:                                   │
-                                │    - gpt-4.1-mini                            │
-                                │    - gpt-5-mini                              │
-                                │    - o3-mini                                 │
-                                └──────────────────────────────────────────────┘
+│  │  Project(s) with Capability Hosts and private dependencies       │                     │
+│  └───────────────────────────────────────────────┬──────────────────┘                     │
+│                                                  │ APIM private endpoint                  │
+│                                                  ▼                                        │
+│                        ┌─────────────────────────────────────────────────────┐            │
+│                        │ Azure API Management Standardv2 (External + PE)     │            │
+│                        │ - Public access controlled by APIM_PUBLIC_ENABLED   │            │
+│                        │ - /inference/openai + /azure APIs                  │            │
+│                        │ - Per-model PAYG pools                              │            │
+│                        └──────────────────────────┬──────────────────────────┘            │
+│                                                   │                                       │
+│  VNet │ Private DNS │ Key Vault │ Storage │ Cosmos │ AI Search │ MCP/OpenAPI services      │
+└───────────────────────────────────────────────────┼───────────────────────────────────────┘
+                                                    │ Private endpoints (one per instance)
+                                                    ▼
+                             ┌──────────────────────────────────────────────┐
+                             │  1..N Foundry / Azure OpenAI instances       │
+                             │  Per-instance, per-model APIM backends       │
+                             └──────────────────────────────────────────────┘
 ```
 
 **Flow:**
-1. Foundry Agent Service calls the internal APIM AI Gateway
-2. APIM proxies requests via private endpoint to external Azure OpenAI
-3. All traffic stays within private network (no public internet)
+1. Foundry Agent Service calls APIM through the APIM private endpoint
+2. APIM extracts the requested model and routes to that model's PAYG pool
+3. APIM reaches each backing instance through a private endpoint in the local VNet
 
 ## Deployed Resources
 
 ### Networking
-- **Virtual Network** with subnets for:
-  - Private Endpoints
-  - APIM (internal mode)
-  - Agent services
-- **Private DNS Zones** for:
-  - Azure OpenAI (`privatelink.openai.azure.com`)
-  - Key Vault, Storage, Cosmos DB, AI Search
-- **Private Endpoint** to external Azure OpenAI resource
+- **Virtual Network** with subnets for private endpoints, APIM external injection, and agent services
+- **Private DNS Zones** for APIM (`privatelink.azure-api.net`), Azure OpenAI (`privatelink.openai.azure.com`), Key Vault, Storage, Cosmos DB, and AI Search
+- **APIM private endpoint**; `APIM_PUBLIC_ENABLED` controls whether public access remains enabled after PE attachment
+- **One private endpoint per backing Foundry / Azure OpenAI instance** so APIM can reach upstream models privately
 
 ### Foundry
 - **Foundry account** with managed identity
@@ -67,12 +50,11 @@ This deployment creates a Foundry environment with an **Azure API Management (AP
 - **AI Dependencies**: Storage, Cosmos DB, AI Search with private endpoints
 
 ### AI Gateway (APIM)
-- **Azure API Management** in internal (VNet-injected) mode
-- Pre-configured static model definitions:
-  - `gpt-4.1-mini`
-  - `gpt-5-mini`
-  - `o3-mini`
-- Managed identity with Cognitive Services User role on external OpenAI
+- **Azure API Management Standardv2** in external VNet-injected mode with private endpoint
+- Per-model backends + PAYG pools synthesised from `FOUNDRY_INSTANCES_JSON`
+- Passthrough `/inference/openai` API and spec-backed `/azure` API
+- Managed identity with Cognitive Services User role on every backing instance
+- Optional `apiServices` entries for private MCP/OpenAPI services are exposed through APIM and private DNS
 
 ### Monitoring
 - **Log Analytics Workspace**
@@ -80,21 +62,35 @@ This deployment creates a Foundry environment with an **Azure API Management (AP
 
 ## Prerequisites
 
-Set the following environment variables before deployment:
+Set the backing Foundry / Azure AI Services instances before deployment:
 
 ```bash
-export OPENAI_API_BASE="https://your-landing-zone-openai.openai.azure.com"
-export OPENAI_RESOURCE_ID="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<openai-name>"
+export EXISTING_FOUNDRY_RESOURCE_IDS="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-1>,/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-2>"
 ```
 
+`EXISTING_FOUNDRY_RESOURCE_IDS` is the preferred comma-separated, multi-instance form. For backwards compatibility, the discovery hook also accepts `EXISTING_FOUNDRY_RESOURCE_ID` or legacy `OPENAI_RESOURCE_ID` for a single instance.
+
+The `azure.yaml` `preprovision` hook runs [`preprovision-list-foundry-models.sh`](../scripts/preprovision-list-foundry-models.sh) / `.ps1`, calls ARM (`az cognitiveservices account deployment list`) to enumerate model deployments on every instance, and writes `FOUNDRY_INSTANCES_JSON`. `main.bicepparam` reads that JSON into the `foundryInstances` parameter using the [`foundryInstanceType[]`](../modules/apim/advanced/types.bicep) shape. Deployment fails fast with a clear error when no instances are configured.
+
 ### Optional Parameters
-- `OPENAI_LOCATION` - Location of the OpenAI resource (defaults to deployment location)
 - `PROJECTS_COUNT` - Number of Foundry projects to create (default: 1)
+- `APIM_PUBLIC_ENABLED` - Set to `true` to keep APIM public access enabled after the private endpoint is attached (default: `false`)
+
+## Per-model smart routing
+
+All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) for APIM orchestration:
+
+- [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) creates one APIM backend per `(instance, model)`, so a throttled deployment only disables that backend while sibling deployments continue serving traffic.
+- One PAYG backend pool is created per model, named `{model-clean}-payg-pool` after removing `.` and `-` from the model name; all instances serving that model join the same pool for APIM load balancing.
+- The shared [`per-model-routing`](../modules/apim/per-model-routing-fragment.xml) policy fragment is wired into both `/inference/openai` and `/azure`. It reads the model from `/deployments/{name}/...` or the request body's `model`, computes `model-clean`, and routes to the matching pool.
+- APIM's system-assigned managed identity is granted **Cognitive Services User** on every backing instance, including instances in other resource groups or subscriptions.
+
+The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
 ## Deployment
 
 ```bash
-cd options-infra/option_ai-gateway-internal
+cd options-infra/ai-gateway-pe
 azd up
 ```
 
@@ -107,17 +103,19 @@ azd up
 | `FOUNDRY_NAME` | Name of the Foundry account |
 | `config_validation_result` | Validation status of the configuration |
 
-## Key Differences from `option_ai-gateway`
-
-| Feature | `option_ai-gateway` | `option_ai-gateway-internal` |
-|---------|---------------------|------------------------------|
-| APIM Mode | External (public IP) | Internal (VNet only) |
-| OpenAI Access | Via public endpoint | Via private endpoint |
-| Network Security | Public accessible | Fully private |
-
 ## Use Cases
 
-- **Enterprise/Regulated environments**: All AI traffic stays within private network
+- **Private APIM access**: Use Standardv2 with a private endpoint while retaining External VNet injection
 - **Centralized AI Gateway**: Single point of control for AI model access
-- **Landing Zone integration**: Connect to shared Azure OpenAI in a hub subscription
-- **Policy enforcement**: Rate limiting, logging, and access control via APIM policies
+- **Landing Zone integration**: Connect privately to shared Foundry / Azure OpenAI instances
+- **Private tool integration**: Publish MCP/OpenAPI services alongside model APIs
+
+## Variants
+
+| Sample | Difference |
+|--------|------------|
+| [ai-gateway-basic](../ai-gateway-basic/) | Public APIM Basicv2, no VNet at all |
+| [ai-gateway](../ai-gateway/) | Public APIM Basicv2 with private Foundry dependencies |
+| [ai-gateway-internal](../ai-gateway-internal/) | Developer SKU with internal VNet injection and per-instance upstream private endpoints |
+| [ai-gateway-pe-custom](../ai-gateway-pe-custom/) | Standardv2 + PE, but provisions its own OpenAI account and test deployments |
+| [ai-gateway-premium](../ai-gateway-premium/) | Premiumv2 internal VNet, custom domain, dedicated APIM VNet |

--- a/options-infra/ai-gateway-pe/azure.yaml
+++ b/options-infra/ai-gateway-pe/azure.yaml
@@ -7,6 +7,21 @@ infra:
   module: main
 
 hooks:
+  preprovision:
+    windows:
+      shell: pwsh
+      run: |
+        & '../scripts/preprovision-list-foundry-models.ps1'
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      interactive: false
+      continueOnError: false
+    posix:
+      shell: sh
+      run: |
+        sh ../scripts/preprovision-list-foundry-models.sh
+      interactive: false
+      continueOnError: false
+
   postprovision:
     shell: sh
     run: |

--- a/options-infra/ai-gateway-pe/main.bicep
+++ b/options-infra/ai-gateway-pe/main.bicep
@@ -7,14 +7,16 @@
 targetScope = 'resourceGroup'
 
 import { apiType } from '../modules/apps/apps-private-link.bicep'
+import { foundryInstanceType } from '../modules/apim/advanced/types.bicep'
+import { ModelType } from '../modules/ai/connection-apim-gateway.bicep'
 
 param location string = resourceGroup().location
-param openAiApiBase string
-param openAiResourceId string
-param openAiLocation string = location
 param projectsCount int = 1
-param apiServices apiType[] = [] // Array of MCP service definitions
+param apiServices apiType[] = []
 param apimPublicEnabled bool = false
+
+@description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON) from EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID. At least one instance is required.')
+param foundryInstances foundryInstanceType[]
 
 var tags = {
   'created-by': 'option-ai-gateway'
@@ -22,15 +24,30 @@ var tags = {
   SecurityControl: 'Ignore'
 }
 
-var valid_config = empty(openAiApiBase) || empty(openAiResourceId)
-  ? fail('OPENAI_API_BASE and OPENAI_RESOURCE_ID environment variables must be set.')
+var valid_config = empty(foundryInstances)
+  ? fail('No Foundry instances configured. Set EXISTING_FOUNDRY_RESOURCE_IDS (or OPENAI_RESOURCE_ID) and run the `preprovision-list-foundry-models` hook so FOUNDRY_INSTANCES_JSON is populated.')
   : true
 
 var resourceToken = toLower(uniqueString(resourceGroup().id, location))
-var openAiParts = split(openAiResourceId, '/')
-var openAiName = last(openAiParts)
-var openAiSubscriptionId = openAiParts[2]
-var openAiResourceGroupName = openAiParts[4]
+
+var allDeployments = flatten(map(foundryInstances, inst => inst.deployments))
+var dedupedDeployments = reduce(
+  allDeployments,
+  [],
+  (acc, d) => contains(map(acc, x => x.modelName), d.modelName) ? acc : concat(acc, [d])
+)
+var staticModels ModelType[] = [
+  for d in dedupedDeployments: {
+    name: d.modelName
+    properties: {
+      model: {
+        name: d.modelName
+        version: d.?modelVersion ?? '2025-01-01-preview'
+        format: d.?modelFormat ?? 'OpenAI'
+      }
+    }
+  }
+]
 
 module foundry_identity '../modules/iam/identity.bicep' = {
   name: 'foundry-identity-deployment'
@@ -67,20 +84,22 @@ module ai_dependencies '../modules/ai/ai-dependencies-with-dns.bicep' = {
   }
 }
 
-// Private endpoint for external OpenAI
-module openai_private_endpoint '../modules/networking/ai-pe-dns.bicep' = {
-  name: 'openai-private-endpoint-and-dns-deployment'
-  params: {
-    tags: tags
-    location: location
-    aiAccountName: openAiName
-    aiAccountNameResourceGroup: openAiResourceGroupName
-    aiAccountSubscriptionId: openAiSubscriptionId
-    peSubnetId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
-    resourceToken: resourceToken
-    existingDnsZones: ai_dependencies.outputs.DNS_ZONES
+// Private endpoint per backing Foundry instance.
+module openai_private_endpoints '../modules/networking/ai-pe-dns.bicep' = [
+  for (instance, i) in foundryInstances: {
+    name: 'openai-pe-${i}-${resourceToken}'
+    params: {
+      tags: tags
+      location: location
+      aiAccountName: last(split(instance.resourceId, '/'))
+      aiAccountNameResourceGroup: split(instance.resourceId, '/')[4]
+      aiAccountSubscriptionId: split(instance.resourceId, '/')[2]
+      peSubnetId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
+      resourceToken: '${resourceToken}-${i}'
+      existingDnsZones: ai_dependencies.outputs.DNS_ZONES
+    }
   }
-}
+]
 
 // --------------------------------------------------------------------------------------------------------------
 // -- Log Analytics Workspace and App Insights ------------------------------------------------------------------
@@ -158,82 +177,42 @@ module projects '../modules/ai/ai-project-with-caphost.bicep' = [
   }
 ]
 
-module ai_gateway '../modules/apim/ai-gateway-pe.bicep' = {
+module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
   name: 'ai-gateway-deployment-${resourceToken}'
   params: {
     tags: tags
     location: location
-    apimPublicEnabled: apimPublicEnabled
     resourceToken: resourceToken
     aiFoundryName: foundry.outputs.FOUNDRY_NAME
+    aiFoundryProjectNames: [for i in range(1, projectsCount): projects[i - 1].outputs.FOUNDRY_PROJECT_NAME]
+    logAnalyticsWorkspaceResourceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
+    appInsightsResourceId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
+    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
+    gatewayAuthenticationType: 'ProjectManagedIdentity'
+    foundryInstances: foundryInstances
+    staticModels: staticModels
+    // External VNet injection + private endpoint. publicNetworkAccess=Disabled
+    // when apimPublicEnabled=false triggers the post-PE flip step inside
+    // per-model-gateway.bicep.
+    apimSku: 'Standardv2'
+    virtualNetworkType: 'External'
     subnetResourceId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.apimv2Subnet.resourceId
     peSubnetResourceId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
-    logAnalyticsWorkspaceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
-    appInsightsId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
-    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
-    aiFoundryProjectNames: [for i in range(1, projectsCount): projects[i - 1].outputs.FOUNDRY_PROJECT_NAME]
-    staticModels: [
-      {
-        name: 'gpt-4.1-mini'
-        properties: {
-          model: {
-            name: 'gpt-4.1-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-4o'
-        properties: {
-          model: {
-            name: 'gpt-4o'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-5-mini'
-        properties: {
-          model: {
-            name: 'gpt-5-mini'
-            version: '2025-04-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'o3-mini'
-        properties: {
-          model: {
-            name: 'o3-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-    ]
-    aiServicesConfig: [
-      {
-        name: openAiName
-        resourceId: openAiResourceId
-        endpoint: openAiApiBase
-        location: openAiLocation
-      }
-    ]
+    publicNetworkAccess: apimPublicEnabled ? 'Enabled' : 'Disabled'
   }
 }
 
-module apim_role_assignment '../modules/iam/role-assignment-cognitiveServices.bicep' = {
-  name: 'apim-role-assignment-deployment-${resourceToken}'
-  scope: resourceGroup(openAiSubscriptionId, openAiResourceGroupName)
-  params: {
-    accountName: openAiName
-    principalId: ai_gateway.outputs.apimPrincipalId
-    roleName: 'Cognitive Services User'
+module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
+  for (instance, i) in foundryInstances: {
+    name: 'apim-role-${i}-${resourceToken}'
+    scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
+    params: {
+      accountName: last(split(instance.resourceId, '/'))
+      principalId: ai_gateway.outputs.apimPrincipalId
+      roleName: 'Cognitive Services User'
+    }
   }
-}
+]
 
 module dashboard_setup '../modules/dashboard/dashboard-setup.bicep' = {
   name: 'dashboard-setup-deployment-${resourceToken}'

--- a/options-infra/ai-gateway-pe/main.bicep
+++ b/options-infra/ai-gateway-pe/main.bicep
@@ -18,6 +18,9 @@ param apimPublicEnabled bool = false
 @description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON) from EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID. At least one instance is required.')
 param foundryInstances foundryInstanceType[]
 
+@description('Tenant IDs whose Entra ID tokens the gateway should accept on inbound calls. Empty (default) = no inbound JWT validation — callers reach the gateway anonymously and APIM\'s managed identity authenticates to Foundry. When set, the inbound policy requires a valid bearer token with `aud=https://cognitiveservices.azure.com` issued by one of these tenants.')
+param acceptedTenantIds string[] = []
+
 var tags = {
   'created-by': 'option-ai-gateway'
   'hidden-title': 'Foundry - APIM v2 Standard with PE'
@@ -85,8 +88,10 @@ module ai_dependencies '../modules/ai/ai-dependencies-with-dns.bicep' = {
 }
 
 // Private endpoint per backing Foundry instance.
+// Skip chained-APIM instances (isApim=true) — they're not Cognitive Services
+// accounts, so no PE is needed; the downstream APIM exposes its own endpoint.
 module openai_private_endpoints '../modules/networking/ai-pe-dns.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'openai-pe-${i}-${resourceToken}'
     params: {
       tags: tags
@@ -191,6 +196,7 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
     gatewayAuthenticationType: 'ProjectManagedIdentity'
     foundryInstances: foundryInstances
     staticModels: staticModels
+    acceptedTenantIds: acceptedTenantIds
     // External VNet injection + private endpoint. publicNetworkAccess=Disabled
     // when apimPublicEnabled=false triggers the post-PE flip step inside
     // per-model-gateway.bicep.
@@ -202,8 +208,11 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
   }
 }
 
+// Grant APIM's managed identity Cognitive Services User on every backing
+// Foundry instance. Skip chained-APIM instances (isApim=true): they auth
+// inbound via JWT, not via RBAC.
 module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'apim-role-${i}-${resourceToken}'
     scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
     params: {

--- a/options-infra/ai-gateway-pe/main.bicepparam
+++ b/options-infra/ai-gateway-pe/main.bicepparam
@@ -1,11 +1,10 @@
 using 'main.bicep'
 
-// Parameters for the main Bicep template
-param openAiApiBase = readEnvironmentVariable('OPENAI_API_BASE', '')
-param openAiResourceId = readEnvironmentVariable('OPENAI_RESOURCE_ID', '')
-
-var openAiLocationValue = readEnvironmentVariable('OPENAI_LOCATION', '')
-param openAiLocation = empty(openAiLocationValue) ? null : openAiLocationValue
+// Foundry instances discovered by the `preprovision-list-foundry-models` hook
+// (reads EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID and writes
+// FOUNDRY_INSTANCES_JSON). At least one instance with at least one deployment
+// is required — main.bicep fails the deployment otherwise.
+param foundryInstances = json(readEnvironmentVariable('FOUNDRY_INSTANCES_JSON', '[]'))
 
 var apimPublicEnabledValue = readEnvironmentVariable('APIM_PUBLIC_ENABLED', '')
 param apimPublicEnabled = toLower(apimPublicEnabledValue) == 'true' ? true : false

--- a/options-infra/ai-gateway-premium/README.md
+++ b/options-infra/ai-gateway-premium/README.md
@@ -1,6 +1,6 @@
 # Option: AI Gateway (APIM v2 Premium VNet Injection - Internal) with Foundry
 
-This deployment creates a Foundry environment with an **Azure API Management v2 Premium** instance deployed in **VNet Injection mode**, acting as an AI Gateway. The goal is to allow **Foundry Agent Service** to use models from APIM, which proxies requests to an external Azure OpenAI resource.
+This deployment creates a Foundry environment with an **Azure API Management Premiumv2** instance deployed in **Internal VNet injection** mode with a custom domain. It lets **Foundry Agent Service** use models from APIM, which proxies requests to **one or more** existing Foundry / Azure OpenAI instances with **per-model smart routing** through [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep).
 
 ## Architecture Overview
 
@@ -9,60 +9,42 @@ This deployment creates a Foundry environment with an **Azure API Management v2 
 │                                    This Deployment                                        │
 │                                                                                           │
 │  ┌──────────────────────────────────────────────────────────────────┐                     │
-│  │                      AI Foundry                                  │                     │
-│  │  ┌─────────────────────────────────────────────────────────────┐ │                     │
-│  │  │  Project(s) with Capability Hosts                           │ │                     │
-│  │  │                                                             │ │                     │
-│  │  │  Agent Service ─── Vnet injection ──────────────────────────┼─┼──┐                  │
-│  │  └─────────────────────────────────────────────────────────────┘ │  │                  │
-│  └──────────────────────────────────────────────────────────────────┘  │                  │
-│                                                                        │                  │
-│                                                                        ▼                  │
-│                                              ┌─────────────────────────────────────────┐  │
-│                                              │   Azure API Management v2 Premium        │  │
-│                                              │   (VNet Injection Mode)                  │  │
-│                                              │   - AI Gateway                           │  │
-│                                              │   - Static Model Definitions            │  │
-│                                              │   - Load Balancing (future)             │  │
-│                                              │   - Rate Limiting / Policies            │  │
-│                                              └──────────────────┬──────────────────────┘  │
-│                                                                 │                         │
-│  ┌──────────────────────────────────────────────────────────────┼───────────────────────┐ │
-│  │                    Supporting Services                       │                       │ │
-│  │  VNet │ Key Vault │ Log Analytics │ App Insights │ Private DNS │ Private Endpoints   │ │
-│  └──────────────────────────────────────────────────────────────┼───────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┼─────────────────────────┘
-                                                                  │
-                                           (Private Endpoint)     │
-                                                                  ▼
-                                ┌──────────────────────────────────────────────┐
-                                │    External: Azure OpenAI (Landing Zone)     │
-                                │                                              │
-                                │    Models:                                   │
-                                │    - gpt-4.1-mini                            │
-                                │    - gpt-5-mini                              │
-                                │    - o3-mini                                 │
-                                └──────────────────────────────────────────────┘
+│  │                      AI Foundry VNet                             │                     │
+│  │  Project(s), private dependencies, upstream private endpoints    │                     │
+│  └───────────────────────────────────────────────┬──────────────────┘                     │
+│                                                  │ VNet peering + linked DNS              │
+│                                                  ▼                                        │
+│  ┌───────────────────────────────────────────────────────────────────────────────┐         │
+│  │ Dedicated APIM VNet                                                           │         │
+│  │  ┌─────────────────────────────────────────────────────────────────────────┐  │         │
+│  │  │ Azure API Management Premiumv2 (Internal)                              │  │         │
+│  │  │ - Custom domain: apim.{customDomain}                                   │  │         │
+│  │  │ - /inference/openai + /azure APIs                                      │  │         │
+│  │  │ - Per-model PAYG pools                                                  │  │         │
+│  │  └───────────────────────────────────────┬─────────────────────────────────┘  │         │
+│  └──────────────────────────────────────────┼────────────────────────────────────┘         │
+│                                             │ Private endpoints (one per instance)          │
+└─────────────────────────────────────────────┼───────────────────────────────────────────────┘
+                                              ▼
+                             ┌──────────────────────────────────────────────┐
+                             │  1..N Foundry / Azure OpenAI instances       │
+                             │  Per-instance, per-model APIM backends       │
+                             └──────────────────────────────────────────────┘
 ```
 
 **Flow:**
-1. Foundry Agent Service calls the internal APIM AI Gateway
-2. APIM proxies requests via private endpoint to external Azure OpenAI
-3. All traffic stays within private network (no public internet)
+1. Foundry Agent Service calls APIM through the internal custom domain `apim.{customDomain}`
+2. APIM extracts the requested model and routes to that model's PAYG pool
+3. APIM reaches each backing instance through a private endpoint in the Foundry VNet
 
 ## Deployed Resources
 
 ### Networking
-- **Main Virtual Network** (`192.168.0.0/21`) with subnets for:
-  - Private Endpoints
-  - Agent services
-- **APIM Virtual Network** (`192.168.100.0/23`) with subnets for:
-  - APIM v2 Premium (VNet Injection)
-- **VNet Peering** between main VNet and APIM VNet
-- **Private DNS Zones** for:
-  - Azure OpenAI (`privatelink.openai.azure.com`)
-  - Key Vault, Storage, Cosmos DB, AI Search
-- **Private Endpoint** to external Azure OpenAI resource
+- **Main Virtual Network** (`192.168.0.0/21`) with subnets for private endpoints and agent services
+- **Dedicated APIM Virtual Network** (`192.168.100.0/23`) for Premiumv2 internal injection
+- **VNet Peering** between the Foundry VNet and APIM VNet
+- **Private DNS Zones** for APIM (`privatelink.azure-api.net`), the custom-domain zone, Azure OpenAI (`privatelink.openai.azure.com`), Key Vault, Storage, Cosmos DB, and AI Search
+- DNS zones are linked to both VNets; one private endpoint is created per backing Foundry / Azure OpenAI instance
 
 ### Foundry
 - **Foundry account** with managed identity
@@ -70,13 +52,13 @@ This deployment creates a Foundry environment with an **Azure API Management v2 
 - **AI Dependencies**: Storage, Cosmos DB, AI Search with private endpoints
 
 ### AI Gateway (APIM v2 Premium)
-- **Azure API Management v2 Premium** in VNet Injection mode
-- Deployed in a dedicated VNet (`192.168.100.0/23`) peered with the main VNet
-- Pre-configured static model definitions:
-  - `gpt-4.1-mini`
-  - `gpt-5-mini`
-  - `o3-mini`
-- Managed identity with Cognitive Services User role on external OpenAI
+- **Azure API Management Premiumv2** in internal VNet-injected mode
+- Custom domain `apim.{customDomain}` backed by a Key Vault PFX certificate accessed through UAMI
+- Lightweight `apim-hostname-update.bicep` deployment applies hostname bindings after APIM creation
+- Per-model backends + PAYG pools synthesised from `FOUNDRY_INSTANCES_JSON`
+- Passthrough `/inference/openai` API and spec-backed `/azure` API
+- Managed identity with Cognitive Services User role on every backing instance
+- Optional `apiServices` entries for private MCP/OpenAPI services are exposed through APIM and private DNS
 
 ### Monitoring
 - **Log Analytics Workspace**
@@ -84,21 +66,35 @@ This deployment creates a Foundry environment with an **Azure API Management v2 
 
 ## Prerequisites
 
-Set the following environment variables before deployment:
+Set the backing Foundry / Azure AI Services instances before deployment:
 
 ```bash
-export OPENAI_API_BASE="https://your-landing-zone-openai.openai.azure.com"
-export OPENAI_RESOURCE_ID="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<openai-name>"
+export EXISTING_FOUNDRY_RESOURCE_IDS="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-1>,/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-2>"
 ```
 
+`EXISTING_FOUNDRY_RESOURCE_IDS` is the preferred comma-separated, multi-instance form. For backwards compatibility, the discovery hook also accepts `EXISTING_FOUNDRY_RESOURCE_ID` or legacy `OPENAI_RESOURCE_ID` for a single instance.
+
+The `azure.yaml` `preprovision` hook runs [`preprovision-list-foundry-models.sh`](../scripts/preprovision-list-foundry-models.sh) / `.ps1`, calls ARM (`az cognitiveservices account deployment list`) to enumerate model deployments on every instance, and writes `FOUNDRY_INSTANCES_JSON`. `main.bicepparam` reads that JSON into the `foundryInstances` parameter using the [`foundryInstanceType[]`](../modules/apim/advanced/types.bicep) shape. Deployment fails fast with a clear error when no instances are configured.
+
 ### Optional Parameters
-- `OPENAI_LOCATION` - Location of the OpenAI resource (defaults to deployment location)
-- `PROJECTS_COUNT` - Number of Foundry projects to create (default: 1)
+- `APIM_LOCATION` - Location for the APIM Premiumv2 instance (defaults to deployment location)
+- `PROJECTS_COUNT` - Number of Foundry projects to create (default: 3)
+
+## Per-model smart routing
+
+All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) for APIM orchestration:
+
+- [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) creates one APIM backend per `(instance, model)`, so a throttled deployment only disables that backend while sibling deployments continue serving traffic.
+- One PAYG backend pool is created per model, named `{model-clean}-payg-pool` after removing `.` and `-` from the model name; all instances serving that model join the same pool for APIM load balancing.
+- The shared [`per-model-routing`](../modules/apim/per-model-routing-fragment.xml) policy fragment is wired into both `/inference/openai` and `/azure`. It reads the model from `/deployments/{name}/...` or the request body's `model`, computes `model-clean`, and routes to the matching pool.
+- APIM's system-assigned managed identity is granted **Cognitive Services User** on every backing instance, including instances in other resource groups or subscriptions.
+
+The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
 ## Deployment
 
 ```bash
-cd options-infra/option_ai-gateway-internal
+cd options-infra/ai-gateway-premium
 azd up
 ```
 
@@ -111,19 +107,19 @@ azd up
 | `FOUNDRY_NAME` | Name of the Foundry account |
 | `config_validation_result` | Validation status of the configuration |
 
-## Key Differences from Other Options
-
-| Feature | `option_ai-gateway` | `option_ai-gateway-internal` | `option_ai-gateway-premium` |
-|---------|---------------------|------------------------------|------------------------------|
-| APIM SKU | v2 Standard | v2 Standard | **v2 Premium** |
-| APIM Mode | External (public IP) | Internal (VNet only) | **VNet Injection** |
-| Network | Single VNet | Single VNet | **Dedicated APIM VNet + Peering** |
-| OpenAI Access | Via public endpoint | Via private endpoint | Via private endpoint |
-| Network Security | Public accessible | Fully private | Fully private |
-
 ## Use Cases
 
-- **Enterprise/Regulated environments**: All AI traffic stays within private network
+- **Enterprise/Regulated environments**: Internal Premiumv2 APIM with custom domain
 - **Centralized AI Gateway**: Single point of control for AI model access
-- **Landing Zone integration**: Connect to shared Azure OpenAI in a hub subscription
-- **Policy enforcement**: Rate limiting, logging, and access control via APIM policies
+- **Landing Zone integration**: Connect privately to shared Foundry / Azure OpenAI instances
+- **Private tool integration**: Publish MCP/OpenAPI services alongside model APIs
+
+## Variants
+
+| Sample | Difference |
+|--------|------------|
+| [ai-gateway-basic](../ai-gateway-basic/) | Public APIM Basicv2, no VNet at all |
+| [ai-gateway](../ai-gateway/) | Public APIM Basicv2 with private Foundry dependencies |
+| [ai-gateway-internal](../ai-gateway-internal/) | Developer SKU with internal VNet injection and per-instance upstream private endpoints |
+| [ai-gateway-pe](../ai-gateway-pe/) | Standardv2 with external VNet injection plus APIM private endpoint |
+| [ai-gateway-pe-custom](../ai-gateway-pe-custom/) | Standardv2 + PE, but provisions its own OpenAI account and test deployments |

--- a/options-infra/ai-gateway-premium/README.md
+++ b/options-infra/ai-gateway-premium/README.md
@@ -91,6 +91,30 @@ All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-g
 
 The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
+## Advanced features
+
+The shared `per-model-gateway` orchestrator supports three opt-in features that work in any sample:
+
+### Anthropic (Claude) models on Foundry
+
+Foundry exposes Claude under `/anthropic/*` instead of `/openai/*`. When a deployment in `FOUNDRY_INSTANCES_JSON` carries `"modelFormat": "Anthropic"`, [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) automatically points that backend at `{endpoint}anthropic` while OpenAI/Cohere/DeepSeek/OpenAI-OSS deployments continue to use `{endpoint}openai`. The same gateway transparently serves both `/deployments/{name}/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape); no separate API is needed.
+
+The discovery script picks up Anthropic deployments natively — no config change required.
+
+### Chaining (APIM-to-APIM)
+
+To front another APIM gateway (one that already follows this per-model-gateway convention) instead of a Cognitive Services account, set `EXISTING_APIM_RESOURCE_IDS` alongside `EXISTING_FOUNDRY_RESOURCE_IDS`. The discovery hook enumerates the downstream APIM's catalog and writes an entry with `"isApim": true` into `FOUNDRY_INSTANCES_JSON`. The orchestrator then:
+
+- Points backends at `{endpoint}inference/openai` (the downstream's passthrough catch-all) regardless of model format — model-format split is the downstream's concern.
+- Skips the per-instance Cognitive Services RBAC role assignment (the downstream authenticates inbound via JWT, not RBAC).
+- Skips per-instance private endpoint creation in network-injected variants (the downstream APIM exposes its own endpoint).
+
+Useful for regional fan-out: one local APIM aggregates several remote APIMs, each fronting their own Foundry accounts.
+
+### Optional inbound JWT validation (`acceptedTenantIds`)
+
+By default the gateway is open — callers reach it anonymously and APIM's managed identity authenticates outbound to Foundry. Set `acceptedTenantIds` to a non-empty list of tenant IDs to require `Authorization: Bearer <token>` on every inbound call with `aud=https://cognitiveservices.azure.com` and an `iss` matching one of the configured tenants (both v1 `sts.windows.net/{tid}/` and v2 `login.microsoftonline.com/{tid}/v2.0` issuers are accepted). Defaults to `[]` for backward compatibility.
+
 ## Deployment
 
 ```bash

--- a/options-infra/ai-gateway-premium/azure.yaml
+++ b/options-infra/ai-gateway-premium/azure.yaml
@@ -7,6 +7,21 @@ infra:
   module: main
 
 hooks:
+  preprovision:
+    windows:
+      shell: pwsh
+      run: |
+        & '../scripts/preprovision-list-foundry-models.ps1'
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      interactive: false
+      continueOnError: false
+    posix:
+      shell: sh
+      run: |
+        sh ../scripts/preprovision-list-foundry-models.sh
+      interactive: false
+      continueOnError: false
+
   postprovision:
     shell: sh
     run: |

--- a/options-infra/ai-gateway-premium/main.bicep
+++ b/options-infra/ai-gateway-premium/main.bicep
@@ -15,6 +15,9 @@ param apiServices apiType[] = []
 @description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON). At least one instance is required.')
 param foundryInstances foundryInstanceType[]
 
+@description('Tenant IDs whose Entra ID tokens the gateway should accept on inbound calls. Empty (default) = no inbound JWT validation — callers reach the gateway anonymously and APIM\'s managed identity authenticates to Foundry. When set, the inbound policy requires a valid bearer token with `aud=https://cognitiveservices.azure.com` issued by one of these tenants.')
+param acceptedTenantIds string[] = []
+
 var certFilePath = '../../../../../.ssh/cloud.karpala.pfx'
 var certFileBase64 = loadFileAsBase64(certFilePath)
 param customDomain string = 'cloud.karpala.org'
@@ -117,8 +120,11 @@ module ai_dependencies '../modules/ai/ai-dependencies-with-dns.bicep' = {
 // Private endpoint per backing Foundry instance — each may live in a different
 // subscription/RG. The PE goes into THIS deployment's VNet so the Internal-VNet
 // APIM can reach the upstream models.
+//
+// Skip chained-APIM instances (isApim=true) — they're not Cognitive Services
+// accounts; the downstream APIM exposes its own endpoint.
 module openai_private_endpoints '../modules/networking/ai-pe-dns.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'openai-pe-${i}-${resourceToken}'
     params: {
       tags: tags
@@ -246,6 +252,7 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
     gatewayAuthenticationType: 'ProjectManagedIdentity'
     foundryInstances: foundryInstances
     staticModels: staticModels
+    acceptedTenantIds: acceptedTenantIds
     // Premium + Internal VNet + KV-cert custom domain
     apimSku: 'Premiumv2'
     virtualNetworkType: 'Internal'
@@ -260,8 +267,11 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
   dependsOn: [dns_zone_linking]
 }
 
+// Grant APIM's managed identity Cognitive Services User on every backing
+// Foundry instance. Skip chained-APIM instances (isApim=true): they auth
+// inbound via JWT, not via RBAC.
 module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'apim-role-${i}-${resourceToken}'
     scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
     params: {

--- a/options-infra/ai-gateway-premium/main.bicep
+++ b/options-infra/ai-gateway-premium/main.bicep
@@ -4,14 +4,16 @@ metadata description = 'Deploys API Management v2 Premium with VNET Injections (
 targetScope = 'resourceGroup'
 
 import { apiType } from '../modules/apps/apps-private-link.bicep'
+import { foundryInstanceType } from '../modules/apim/advanced/types.bicep'
+import { ModelType } from '../modules/ai/connection-apim-gateway.bicep'
 
 param location string = resourceGroup().location
 param apimLocation string = location
-param openAiApiBase string
-param openAiResourceId string
-param openAiLocation string = location
 param projectsCount int = 3
-param apiServices apiType[] = [] // Array of MCP service definitions
+param apiServices apiType[] = []
+
+@description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON). At least one instance is required.')
+param foundryInstances foundryInstanceType[]
 
 var certFilePath = '../../../../../.ssh/cloud.karpala.pfx'
 var certFileBase64 = loadFileAsBase64(certFilePath)
@@ -23,15 +25,30 @@ var tags = {
   SecurityControl: 'Ignore'
 }
 
-var valid_config = empty(openAiApiBase) || empty(openAiResourceId)
-  ? fail('OPENAI_API_BASE and OPENAI_RESOURCE_ID environment variables must be set.')
+var valid_config = empty(foundryInstances)
+  ? fail('No Foundry instances configured. Set EXISTING_FOUNDRY_RESOURCE_IDS (or OPENAI_RESOURCE_ID) and run the `preprovision-list-foundry-models` hook so FOUNDRY_INSTANCES_JSON is populated.')
   : true
 
 var resourceToken = toLower(uniqueString(resourceGroup().id, location))
-var openAiParts = split(openAiResourceId, '/')
-var openAiName = last(openAiParts)
-var openAiSubscriptionId = openAiParts[2]
-var openAiResourceGroupName = openAiParts[4]
+
+var allDeployments = flatten(map(foundryInstances, inst => inst.deployments))
+var dedupedDeployments = reduce(
+  allDeployments,
+  [],
+  (acc, d) => contains(map(acc, x => x.modelName), d.modelName) ? acc : concat(acc, [d])
+)
+var staticModels ModelType[] = [
+  for d in dedupedDeployments: {
+    name: d.modelName
+    properties: {
+      model: {
+        name: d.modelName
+        version: d.?modelVersion ?? '2025-01-01-preview'
+        format: d.?modelFormat ?? 'OpenAI'
+      }
+    }
+  }
+]
 
 module foundry_identity '../modules/iam/identity.bicep' = {
   name: 'foundry-identity-deployment'
@@ -97,20 +114,24 @@ module ai_dependencies '../modules/ai/ai-dependencies-with-dns.bicep' = {
   }
 }
 
-// Private endpoint for external OpenAI
-module openai_private_endpoint '../modules/networking/ai-pe-dns.bicep' = {
-  name: 'openai-private-endpoint-and-dns-deployment'
-  params: {
-    tags: tags
-    location: location
-    aiAccountName: openAiName
-    aiAccountNameResourceGroup: openAiResourceGroupName
-    aiAccountSubscriptionId: openAiSubscriptionId
-    peSubnetId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
-    resourceToken: resourceToken
-    existingDnsZones: ai_dependencies.outputs.DNS_ZONES
+// Private endpoint per backing Foundry instance — each may live in a different
+// subscription/RG. The PE goes into THIS deployment's VNet so the Internal-VNet
+// APIM can reach the upstream models.
+module openai_private_endpoints '../modules/networking/ai-pe-dns.bicep' = [
+  for (instance, i) in foundryInstances: {
+    name: 'openai-pe-${i}-${resourceToken}'
+    params: {
+      tags: tags
+      location: location
+      aiAccountName: last(split(instance.resourceId, '/'))
+      aiAccountNameResourceGroup: split(instance.resourceId, '/')[4]
+      aiAccountSubscriptionId: split(instance.resourceId, '/')[2]
+      peSubnetId: vnet.outputs.VIRTUAL_NETWORK_SUBNETS.peSubnet.resourceId
+      resourceToken: '${resourceToken}-${i}'
+      existingDnsZones: ai_dependencies.outputs.DNS_ZONES
+    }
   }
-}
+]
 
 // --------------------------------------------------------------------------------------------------------------
 // -- Log Analytics Workspace and App Insights ------------------------------------------------------------------
@@ -211,86 +232,45 @@ module projects '../modules/ai/ai-project-with-caphost.bicep' = [
   }
 ]
 
-module ai_gateway '../modules/apim/ai-gateway-premium.bicep' = {
+module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
   name: 'ai-gateway-deployment-${resourceToken}'
   params: {
     tags: tags
     location: apimLocation
     resourceToken: resourceToken
     aiFoundryName: foundry.outputs.FOUNDRY_NAME
-    subnetResourceId: apim_vnet.outputs.VIRTUAL_NETWORK_SUBNETS.apimv2PremiumSubnet.resourceId
-    vnetResourceIdsForDnsLink: [apim_vnet.outputs.VIRTUAL_NETWORK_RESOURCE_ID, vnet.outputs.VIRTUAL_NETWORK_RESOURCE_ID]
-    logAnalyticsWorkspaceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
-    appInsightsId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
-    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
-    apimUserAssignedManagedIdentityResourceId: apim_identity.outputs.MANAGED_IDENTITY_RESOURCE_ID
-    certificateKeyVaultUri: keyVault_for_apim.outputs.KEY_VAULT_SECRETS_URIS[0]
-    keyVaultName: keyVault_for_apim.outputs.KEY_VAULT_NAME
-    customDomain: customDomain
     aiFoundryProjectNames: [for i in range(1, projectsCount): projects[i - 1].outputs.FOUNDRY_PROJECT_NAME]
-    staticModels: [
-      {
-        name: 'gpt-4.1-mini'
-        properties: {
-          model: {
-            name: 'gpt-4.1-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-4o'
-        properties: {
-          model: {
-            name: 'gpt-4o'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-5-mini'
-        properties: {
-          model: {
-            name: 'gpt-5-mini'
-            version: '2025-04-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'o3-mini'
-        properties: {
-          model: {
-            name: 'o3-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-    ]
-    aiServicesConfig: [
-      {
-        name: openAiName
-        resourceId: openAiResourceId
-        endpoint: openAiApiBase
-        location: openAiLocation
-      }
-    ]
+    logAnalyticsWorkspaceResourceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
+    appInsightsResourceId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
+    appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
+    gatewayAuthenticationType: 'ProjectManagedIdentity'
+    foundryInstances: foundryInstances
+    staticModels: staticModels
+    // Premium + Internal VNet + KV-cert custom domain
+    apimSku: 'Premiumv2'
+    virtualNetworkType: 'Internal'
+    subnetResourceId: apim_vnet.outputs.VIRTUAL_NETWORK_SUBNETS.apimv2PremiumSubnet.resourceId
+    apimManagedIdentityType: 'SystemAssigned, UserAssigned'
+    apimUserAssignedManagedIdentityResourceId: apim_identity.outputs.MANAGED_IDENTITY_RESOURCE_ID
+    customDomain: customDomain
+    keyVaultName: keyVault_for_apim.outputs.KEY_VAULT_NAME
+    certificateKeyVaultUri: keyVault_for_apim.outputs.KEY_VAULT_SECRETS_URIS[0]
+    vnetResourceIdsForDnsLink: [apim_vnet.outputs.VIRTUAL_NETWORK_RESOURCE_ID, vnet.outputs.VIRTUAL_NETWORK_RESOURCE_ID]
   }
   dependsOn: [dns_zone_linking]
 }
 
-module apim_role_assignment '../modules/iam/role-assignment-cognitiveServices.bicep' = {
-  name: 'apim-role-assignment-deployment-${resourceToken}'
-  scope: resourceGroup(openAiSubscriptionId, openAiResourceGroupName)
-  params: {
-    accountName: openAiName
-    principalId: ai_gateway.outputs.apimPrincipalId
-    roleName: 'Cognitive Services User'
+module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
+  for (instance, i) in foundryInstances: {
+    name: 'apim-role-${i}-${resourceToken}'
+    scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
+    params: {
+      accountName: last(split(instance.resourceId, '/'))
+      principalId: ai_gateway.outputs.apimPrincipalId
+      roleName: 'Cognitive Services User'
+    }
   }
-}
+]
 
 module dashboard_setup '../modules/dashboard/dashboard-setup.bicep' = {
   name: 'dashboard-setup-deployment-${resourceToken}'

--- a/options-infra/ai-gateway-premium/main.bicepparam
+++ b/options-infra/ai-gateway-premium/main.bicepparam
@@ -1,11 +1,10 @@
 using 'main.bicep'
 
-// Parameters for the main Bicep template
-param openAiApiBase = readEnvironmentVariable('OPENAI_API_BASE', '')
-param openAiResourceId = readEnvironmentVariable('OPENAI_RESOURCE_ID', '')
-
-var openAiLocationValue = readEnvironmentVariable('OPENAI_LOCATION', '')
-param openAiLocation = empty(openAiLocationValue) ? null : openAiLocationValue
+// Foundry instances discovered by the `preprovision-list-foundry-models` hook
+// (reads EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID and writes
+// FOUNDRY_INSTANCES_JSON). At least one instance with at least one deployment
+// is required — main.bicep fails the deployment otherwise.
+param foundryInstances = json(readEnvironmentVariable('FOUNDRY_INSTANCES_JSON', '[]'))
 
 var apimLocationValue = readEnvironmentVariable('APIM_LOCATION', '')
 param apimLocation = empty(apimLocationValue) ? null : apimLocationValue

--- a/options-infra/ai-gateway/README.md
+++ b/options-infra/ai-gateway/README.md
@@ -84,6 +84,30 @@ All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-g
 
 The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
+## Advanced features
+
+The shared `per-model-gateway` orchestrator supports three opt-in features that work in any sample:
+
+### Anthropic (Claude) models on Foundry
+
+Foundry exposes Claude under `/anthropic/*` instead of `/openai/*`. When a deployment in `FOUNDRY_INSTANCES_JSON` carries `"modelFormat": "Anthropic"`, [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) automatically points that backend at `{endpoint}anthropic` while OpenAI/Cohere/DeepSeek/OpenAI-OSS deployments continue to use `{endpoint}openai`. The same gateway transparently serves both `/deployments/{name}/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape); no separate API is needed.
+
+The discovery script picks up Anthropic deployments natively — no config change required.
+
+### Chaining (APIM-to-APIM)
+
+To front another APIM gateway (one that already follows this per-model-gateway convention) instead of a Cognitive Services account, set `EXISTING_APIM_RESOURCE_IDS` alongside `EXISTING_FOUNDRY_RESOURCE_IDS`. The discovery hook enumerates the downstream APIM's catalog and writes an entry with `"isApim": true` into `FOUNDRY_INSTANCES_JSON`. The orchestrator then:
+
+- Points backends at `{endpoint}inference/openai` (the downstream's passthrough catch-all) regardless of model format — model-format split is the downstream's concern.
+- Skips the per-instance Cognitive Services RBAC role assignment (the downstream authenticates inbound via JWT, not RBAC).
+- Skips per-instance private endpoint creation in network-injected variants (the downstream APIM exposes its own endpoint).
+
+Useful for regional fan-out: one local APIM aggregates several remote APIMs, each fronting their own Foundry accounts.
+
+### Optional inbound JWT validation (`acceptedTenantIds`)
+
+By default the gateway is open — callers reach it anonymously and APIM's managed identity authenticates outbound to Foundry. Set `acceptedTenantIds` to a non-empty list of tenant IDs to require `Authorization: Bearer <token>` on every inbound call with `aud=https://cognitiveservices.azure.com` and an `iss` matching one of the configured tenants (both v1 `sts.windows.net/{tid}/` and v2 `login.microsoftonline.com/{tid}/v2.0` issuers are accepted). Defaults to `[]` for backward compatibility.
+
 ## Deployment
 
 ```bash

--- a/options-infra/ai-gateway/README.md
+++ b/options-infra/ai-gateway/README.md
@@ -1,6 +1,6 @@
 # Option: AI Gateway (External APIM) with Foundry
 
-This deployment creates a Foundry environment with an **external Azure API Management (APIM) Basic v2** instance acting as an AI Gateway. The goal is to allow **Foundry Agent Service** to use models from APIM, which proxies requests to an external Azure OpenAI resource.
+This deployment creates a Foundry environment with an **external Azure API Management (APIM) Basic v2** instance acting as an AI Gateway. It lets **Foundry Agent Service** use models from APIM, which proxies requests to **one or more** existing Foundry / Azure OpenAI instances with **per-model smart routing** through [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep).
 
 ## Architecture Overview
 
@@ -10,53 +10,38 @@ This deployment creates a Foundry environment with an **external Azure API Manag
 │                                                                                           │
 │  ┌──────────────────────────────────────────────────────────────────┐                     │
 │  │                      AI Foundry                                  │                     │
-│  │  ┌─────────────────────────────────────────────────────────────┐ │                     │
-│  │  │  Project(s) with Capability Hosts                           │ │                     │
-│  │  │                                                             │ │                     │
-│  │  │  Agent Service ─────────────────────────────────────────────┼─┼──┐                  │
-│  │  └─────────────────────────────────────────────────────────────┘ │  │                  │
-│  └──────────────────────────────────────────────────────────────────┘  │                  │
-│                                                                        │                  │
-│                                                                        ▼                  │
-│                                              ┌─────────────────────────────────────────┐  │
-│                                              │   Azure API Management (External)       │  │
-│                                              │   - AI Gateway                          │  │
-│                                              │   - Public IP                           │  │
-│                                              │   - Static Model Definitions            │  │
-│                                              │   - Rate Limiting / Policies            │  │
-│                                              └──────────────────┬──────────────────────┘  │
-│                                                                 │                         │
-│  ┌──────────────────────────────────────────────────────────────┼───────────────────────┐ │
-│  │                    Supporting Services                       │                       │ │
-│  │  VNet │ Key Vault │ Log Analytics │ App Insights │ Private DNS                       │ │
-│  └──────────────────────────────────────────────────────────────┼───────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┼─────────────────────────┘
-                                                                  │
-                                          (Public Internet)       │
-                                                                  ▼
-                                ┌──────────────────────────────────────────────┐
-                                │    External: Azure OpenAI (Landing Zone)     │
-                                │                                              │
-                                │    Models:                                   │
-                                │    - gpt-4.1-mini                            │
-                                │    - gpt-5-mini                              │
-                                │    - o3-mini                                 │
-                                └──────────────────────────────────────────────┘
+│  │  Project(s) with Capability Hosts                                │                     │
+│  │  Dependencies use VNet + private endpoints                       │                     │
+│  └───────────────────────────────────────────────┬──────────────────┘                     │
+│                                                  │                                        │
+│                                                  ▼                                        │
+│                        ┌─────────────────────────────────────────────────────┐            │
+│                        │ Azure API Management Basicv2 (Public)               │            │
+│                        │ - /inference/openai + /azure APIs                  │            │
+│                        │ - Per-model routing fragment                        │            │
+│                        │ - PAYG pools: {model-clean}-payg-pool             │            │
+│                        └──────────────────────────┬──────────────────────────┘            │
+│                                                   │                                       │
+│  Supporting Services: VNet │ Key Vault │ Storage │ Cosmos │ AI Search │ Private DNS       │
+└───────────────────────────────────────────────────┼───────────────────────────────────────┘
+                                                    │ Public Internet
+                                                    ▼
+                             ┌──────────────────────────────────────────────┐
+                             │  1..N Foundry / Azure OpenAI instances       │
+                             │  Per-instance, per-model APIM backends       │
+                             └──────────────────────────────────────────────┘
 ```
 
 **Flow:**
-1. Foundry Agent Service calls the external APIM AI Gateway
-2. APIM proxies requests over public internet to Azure OpenAI
-3. APIM uses managed identity for authentication to Azure OpenAI
+1. Foundry Agent Service calls the public APIM AI Gateway
+2. APIM extracts the requested model and routes to that model's PAYG pool
+3. APIM uses managed identity for authentication to the selected Foundry / Azure OpenAI instance
 
 ## Deployed Resources
 
 ### Networking
-- **Virtual Network** with subnets for:
-  - Private Endpoints
-  - Agent services
-- **Private DNS Zones** for:
-  - Key Vault, Storage, Cosmos DB, AI Search
+- **Virtual Network** with subnets for private endpoints and agent services
+- **Private DNS Zones** for Key Vault, Storage, Cosmos DB, and AI Search
 
 ### Foundry
 - **Foundry account** with managed identity (or use existing)
@@ -64,12 +49,10 @@ This deployment creates a Foundry environment with an **external Azure API Manag
 - **AI Dependencies**: Storage, Cosmos DB, AI Search with private endpoints
 
 ### AI Gateway (APIM)
-- **Azure API Management** in external mode (public IP)
-- Pre-configured static model definitions:
-  - `gpt-4.1-mini`
-  - `gpt-5-mini`
-  - `o3-mini`
-- Managed identity with Cognitive Services User role on external OpenAI
+- **Azure API Management Basicv2** in external/public mode
+- Per-model backends + PAYG pools synthesised from `FOUNDRY_INSTANCES_JSON`
+- Passthrough `/inference/openai` API and spec-backed `/azure` API
+- Managed identity with Cognitive Services User role on every backing instance
 
 ### Monitoring
 - **Log Analytics Workspace**
@@ -77,21 +60,34 @@ This deployment creates a Foundry environment with an **external Azure API Manag
 
 ## Prerequisites
 
-Set the following environment variables before deployment:
+Set the backing Foundry / Azure AI Services instances before deployment:
 
 ```bash
-export OPENAI_API_BASE="https://your-landing-zone-openai.openai.azure.com"
-export OPENAI_RESOURCE_ID="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<openai-name>"
+export EXISTING_FOUNDRY_RESOURCE_IDS="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-1>,/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-2>"
 ```
 
+`EXISTING_FOUNDRY_RESOURCE_IDS` is the preferred comma-separated, multi-instance form. For backwards compatibility, the discovery hook also accepts `EXISTING_FOUNDRY_RESOURCE_ID` or legacy `OPENAI_RESOURCE_ID` for a single instance.
+
+The `azure.yaml` `preprovision` hook runs [`preprovision-list-foundry-models.sh`](../scripts/preprovision-list-foundry-models.sh) / `.ps1`, calls ARM (`az cognitiveservices account deployment list`) to enumerate model deployments on every instance, and writes `FOUNDRY_INSTANCES_JSON`. `main.bicepparam` reads that JSON into the `foundryInstances` parameter using the [`foundryInstanceType[]`](../modules/apim/advanced/types.bicep) shape. Deployment fails fast with a clear error when no instances are configured.
+
 ### Optional Parameters
-- `OPENAI_LOCATION` - Location of the OpenAI resource (defaults to deployment location)
 - `PROJECTS_COUNT` - Number of Foundry projects to create (default: 1)
+
+## Per-model smart routing
+
+All gateway variants use [`per-model-gateway.bicep`](../modules/apim/per-model-gateway.bicep) for APIM orchestration:
+
+- [`multi-foundry-backends.bicep`](../modules/apim/advanced/multi-foundry-backends.bicep) creates one APIM backend per `(instance, model)`, so a throttled deployment only disables that backend while sibling deployments continue serving traffic.
+- One PAYG backend pool is created per model, named `{model-clean}-payg-pool` after removing `.` and `-` from the model name; all instances serving that model join the same pool for APIM load balancing.
+- The shared [`per-model-routing`](../modules/apim/per-model-routing-fragment.xml) policy fragment is wired into both `/inference/openai` and `/azure`. It reads the model from `/deployments/{name}/...` or the request body's `model`, computes `model-clean`, and routes to the matching pool.
+- APIM's system-assigned managed identity is granted **Cognitive Services User** on every backing instance, including instances in other resource groups or subscriptions.
+
+The gateway does not enforce quotas, JWT validation, or access contracts; those controls live in the `ai-gateway-quota` sample. The spec-backed `/azure` API renders the APIM test console and model-discovery endpoints from [`FOUNDRY_INSTANCES_JSON`](../modules/apim/advanced/types.bicep).
 
 ## Deployment
 
 ```bash
-cd options-infra/option_ai-gateway
+cd options-infra/ai-gateway
 azd up
 ```
 
@@ -104,19 +100,19 @@ azd up
 | `FOUNDRY_NAME` | Name of the Foundry account |
 | `config_validation_result` | Validation status of the configuration |
 
-## Key Differences from `option_ai-gateway-internal`
-
-| Feature | `option_ai-gateway` | `option_ai-gateway-internal` |
-|---------|---------------------|------------------------------|
-| APIM Mode | External (public IP) | Internal (VNet only) |
-| OpenAI Access | Via public internet | Via private endpoint |
-| Network Security | Public accessible | Fully private |
-| Use Case | Dev/Test, simpler setup | Enterprise/Production |
-
 ## Use Cases
 
-- **Development/Testing**: Quick setup without private networking complexity
+- **Development/Testing**: Public APIM with private Foundry dependencies
 - **Centralized AI Gateway**: Single point of control for AI model access
-- **Landing Zone integration**: Connect to shared Azure OpenAI in a hub subscription
-- **Policy enforcement**: Rate limiting, logging, and access control via APIM policies
+- **Landing Zone integration**: Connect to shared Foundry / Azure OpenAI instances
 - **Existing Foundry**: Can attach to an existing Foundry account
+
+## Variants
+
+| Sample | Difference |
+|--------|------------|
+| [ai-gateway-basic](../ai-gateway-basic/) | Public APIM Basicv2, no VNet at all |
+| [ai-gateway-internal](../ai-gateway-internal/) | Developer SKU with internal VNet injection and per-instance upstream private endpoints |
+| [ai-gateway-pe](../ai-gateway-pe/) | Standardv2 with external VNet injection plus APIM private endpoint |
+| [ai-gateway-pe-custom](../ai-gateway-pe-custom/) | Standardv2 + PE, but provisions its own OpenAI account and test deployments |
+| [ai-gateway-premium](../ai-gateway-premium/) | Premiumv2 internal VNet, custom domain, dedicated APIM VNet |

--- a/options-infra/ai-gateway/azure.yaml
+++ b/options-infra/ai-gateway/azure.yaml
@@ -7,6 +7,26 @@ infra:
   module: main
 
 hooks:
+  # Preprovision: discover model deployments on the existing Foundry
+  # instance(s) (EXISTING_FOUNDRY_RESOURCE_IDS / EXISTING_FOUNDRY_RESOURCE_ID
+  # / OPENAI_RESOURCE_ID fallback) and write them to FOUNDRY_INSTANCES_JSON in
+  # the foundryInstanceType[] shape main.bicepparam consumes. If no inputs are
+  # set, the script writes [] and main.bicep fails with a clear error.
+  preprovision:
+    windows:
+      shell: pwsh
+      run: |
+        & '../scripts/preprovision-list-foundry-models.ps1'
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      interactive: false
+      continueOnError: false
+    posix:
+      shell: sh
+      run: |
+        sh ../scripts/preprovision-list-foundry-models.sh
+      interactive: false
+      continueOnError: false
+
   postprovision:
     shell: sh
     run: |

--- a/options-infra/ai-gateway/main.bicep
+++ b/options-infra/ai-gateway/main.bicep
@@ -16,6 +16,9 @@ param projectsCount int = 3
 @description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON) from EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID. At least one instance is required.')
 param foundryInstances foundryInstanceType[]
 
+@description('Tenant IDs whose Entra ID tokens the gateway should accept on inbound calls. Empty (default) = no inbound JWT validation — callers reach the gateway anonymously and APIM\'s managed identity authenticates to Foundry. When set, the inbound policy requires a valid bearer token with `aud=https://cognitiveservices.azure.com` issued by one of these tenants.')
+param acceptedTenantIds string[] = []
+
 var tags = {
   'created-by': 'option-ai-gateway'
   'hidden-title': 'Foundry - APIM v2 Basic Public'
@@ -180,14 +183,20 @@ module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
     gatewayAuthenticationType: 'ProjectManagedIdentity'
     foundryInstances: foundryInstances
     staticModels: staticModels
+    acceptedTenantIds: acceptedTenantIds
   }
 }
 
 // Grant APIM's managed identity Cognitive Services User on every backing
 // Foundry instance — each instance may live in a different RG (and even a
 // different subscription) so we scope per-resourceId.
+//
+// Skip chained-APIM instances (isApim=true): they authenticate inbound
+// via JWT (the downstream's `validate-jwt` checks our MI token's tenant),
+// not via RBAC. They also typically live outside our subscription/tenant,
+// so the role assignment would fail anyway.
 module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
-  for (instance, i) in foundryInstances: {
+  for (instance, i) in foundryInstances: if (!(instance.?isApim ?? false)) {
     name: 'apim-role-${i}-${resourceToken}'
     scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
     params: {

--- a/options-infra/ai-gateway/main.bicep
+++ b/options-infra/ai-gateway/main.bicep
@@ -2,15 +2,19 @@
 // 1. Foundry dependencies, such as VNet and
 //    private endpoints for AI Search, Azure Storage and Cosmos DB
 // 2. Foundry account and projects
-// 3. APIM as AI Gateway to allow Foundry Agent Service to use models from APIM
+// 3. APIM as AI Gateway (per-model routing) in front of one or more EXISTING
+//    Foundry / AI Services instances — see modules/apim/per-model-gateway.bicep.
 // 4. Projects with capability hosts - in Foundry Standard mode
 targetScope = 'resourceGroup'
 
+import { foundryInstanceType } from '../modules/apim/advanced/types.bicep'
+import { ModelType } from '../modules/ai/connection-apim-gateway.bicep'
+
 param location string = resourceGroup().location
-param openAiApiBase string
-param openAiResourceId string
-param openAiLocation string = location
 param projectsCount int = 3
+
+@description('Existing Foundry / AI Services instances to front with the gateway. Discovered by the `preprovision-list-foundry-models` hook (FOUNDRY_INSTANCES_JSON) from EXISTING_FOUNDRY_RESOURCE_IDS / OPENAI_RESOURCE_ID. At least one instance is required.')
+param foundryInstances foundryInstanceType[]
 
 var tags = {
   'created-by': 'option-ai-gateway'
@@ -18,15 +22,33 @@ var tags = {
   SecurityControl: 'Ignore'
 }
 
-var valid_config = empty(openAiApiBase) || empty(openAiResourceId)
-  ? fail('OPENAI_API_BASE and OPENAI_RESOURCE_ID environment variables must be set.')
+var valid_config = empty(foundryInstances)
+  ? fail('No Foundry instances configured. Set EXISTING_FOUNDRY_RESOURCE_IDS (or OPENAI_RESOURCE_ID) and run the `preprovision-list-foundry-models` hook so FOUNDRY_INSTANCES_JSON is populated.')
   : true
 
 var resourceToken = toLower(uniqueString(resourceGroup().id, location))
-var openAiParts = split(openAiResourceId, '/')
-var openAiName = last(openAiParts)
-var openAiSubscriptionId = openAiParts[2]
-var openAiResourceGroupName = openAiParts[4]
+
+// Union of all deployments across all instances → ModelType[] for the Foundry
+// connection's portal model picker. Dedupes by modelName (first wins when
+// multiple instances serve the same model).
+var allDeployments = flatten(map(foundryInstances, inst => inst.deployments))
+var dedupedDeployments = reduce(
+  allDeployments,
+  [],
+  (acc, d) => contains(map(acc, x => x.modelName), d.modelName) ? acc : concat(acc, [d])
+)
+var staticModels ModelType[] = [
+  for d in dedupedDeployments: {
+    name: d.modelName
+    properties: {
+      model: {
+        name: d.modelName
+        version: d.?modelVersion ?? '2025-01-01-preview'
+        format: d.?modelFormat ?? 'OpenAI'
+      }
+    }
+  }
+]
 
 module foundry_identity '../modules/iam/identity.bicep' = {
   name: 'foundry-identity-deployment'
@@ -144,7 +166,7 @@ module projects '../modules/ai/ai-project-with-caphost.bicep' = [
   }
 ]
 
-module ai_gateway '../modules/apim/ai-gateway.bicep' = {
+module ai_gateway '../modules/apim/per-model-gateway.bicep' = {
   name: 'ai-gateway-deployment-${resourceToken}'
   params: {
     tags: tags
@@ -155,68 +177,26 @@ module ai_gateway '../modules/apim/ai-gateway.bicep' = {
     logAnalyticsWorkspaceResourceId: logAnalytics.outputs.LOG_ANALYTICS_WORKSPACE_RESOURCE_ID
     appInsightsResourceId: logAnalytics.outputs.APPLICATION_INSIGHTS_RESOURCE_ID
     appInsightsInstrumentationKey: logAnalytics.outputs.APPLICATION_INSIGHTS_INSTRUMENTATION_KEY
-    staticModels: [
-      {
-        name: 'gpt-4.1-mini'
-        properties: {
-          model: {
-            name: 'gpt-4.1-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-4o'
-        properties: {
-          model: {
-            name: 'gpt-4o'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'gpt-5-mini'
-        properties: {
-          model: {
-            name: 'gpt-5-mini'
-            version: '2025-04-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-      {
-        name: 'o3-mini'
-        properties: {
-          model: {
-            name: 'o3-mini'
-            version: '2025-01-01-preview'
-            format: 'OpenAI'
-          }
-        }
-      }
-    ]
-    aiServicesConfig: [
-      {
-        name: openAiName
-        resourceId: openAiResourceId
-        endpoint: openAiApiBase
-        location: openAiLocation
-      }
-    ]
+    gatewayAuthenticationType: 'ProjectManagedIdentity'
+    foundryInstances: foundryInstances
+    staticModels: staticModels
   }
 }
 
-module apim_role_assignment '../modules/iam/role-assignment-cognitiveServices.bicep' = {
-  name: 'apim-role-assignment-deployment-${resourceToken}'
-  scope: resourceGroup(openAiSubscriptionId, openAiResourceGroupName)
-  params: {
-    accountName: openAiName
-    principalId: ai_gateway.outputs.apimPrincipalId
-    roleName: 'Cognitive Services User'
+// Grant APIM's managed identity Cognitive Services User on every backing
+// Foundry instance — each instance may live in a different RG (and even a
+// different subscription) so we scope per-resourceId.
+module apim_role_assignments '../modules/iam/role-assignment-cognitiveServices.bicep' = [
+  for (instance, i) in foundryInstances: {
+    name: 'apim-role-${i}-${resourceToken}'
+    scope: resourceGroup(split(instance.resourceId, '/')[2], split(instance.resourceId, '/')[4])
+    params: {
+      accountName: last(split(instance.resourceId, '/'))
+      principalId: ai_gateway.outputs.apimPrincipalId
+      roleName: 'Cognitive Services User'
+    }
   }
-}
+]
 
 module dashboard_setup '../modules/dashboard/dashboard-setup.bicep' = {
   name: 'dashboard-setup-deployment-${resourceToken}'

--- a/options-infra/ai-gateway/main.bicepparam
+++ b/options-infra/ai-gateway/main.bicepparam
@@ -1,8 +1,15 @@
 using 'main.bicep'
 
-// Parameters for the main Bicep template
-param openAiApiBase = readEnvironmentVariable('OPENAI_API_BASE', '')
-param openAiResourceId = readEnvironmentVariable('OPENAI_RESOURCE_ID', '')
+// Foundry instances (with their model deployments) are discovered by the
+// `preprovision-list-foundry-models` hook (../scripts/preprovision-list-foundry-models.{sh,ps1})
+// from EXISTING_FOUNDRY_RESOURCE_IDS (comma-separated) — or as a fallback,
+// the single OPENAI_RESOURCE_ID used by AI Gateway samples. The hook writes
+// FOUNDRY_INSTANCES_JSON in the shape Bicep's `foundryInstanceType[]` expects
+// (defined in options-infra/modules/apim/advanced/types.bicep).
+//
+// At least one instance with at least one deployment is required —
+// main.bicep fails the deployment otherwise.
+param foundryInstances = json(readEnvironmentVariable('FOUNDRY_INSTANCES_JSON', '[]'))
 
-var openAiLocationValue = readEnvironmentVariable('OPENAI_LOCATION', '')
-param openAiLocation = empty(openAiLocationValue) ? null : openAiLocationValue
+var projectsCountValue = readEnvironmentVariable('PROJECTS_COUNT', '')
+param projectsCount = empty(projectsCountValue) ? null : int(projectsCountValue)

--- a/options-infra/modules/apim/advanced/multi-foundry-backends.bicep
+++ b/options-infra/modules/apim/advanced/multi-foundry-backends.bicep
@@ -54,6 +54,20 @@ var allDeployments = flatten(map(
       priority: instance.?priority ?? (instance.isPtu ? 1 : 2)
       weight: instance.?weight ?? 1
       location: instance.location
+      // Foundry exposes Anthropic models under /anthropic/* and everything
+      // else (OpenAI, AzureML, Cohere, DeepSeek, OpenAI-OSS) under /openai/*.
+      // The backend URL just needs the right base path — APIM appends the
+      // remainder of the inbound URL as-is, so the same gateway API serves
+      // both `/deployments/{name}/chat/completions` (OpenAI shape) and
+      // `/v1/messages` (Anthropic shape) transparently.
+      //
+      // For chained-APIM instances (isApim=true) the suffix is always
+      // `inference/openai` because the downstream APIM's passthrough catch-all
+      // lives at that path and routes by model name internally — the
+      // model-format split is the downstream's concern, not ours.
+      backendBasePath: (instance.?isApim ?? false)
+        ? 'inference/openai'
+        : (dep.?modelFormat == 'Anthropic' ? 'anthropic' : 'openai')
     })
 ))
 
@@ -65,7 +79,7 @@ resource backends 'Microsoft.ApiManagement/service/backends@2024-06-01-preview' 
     name: dep.backendName
     properties: {
       description: '${dep.isPtu ? 'PTU' : 'Paygo'} backend: ${dep.instanceName} (${dep.location}) — model ${dep.modelName}'
-      url: '${dep.endpoint}openai'
+      url: '${dep.endpoint}${dep.backendBasePath}'
       protocol: 'http'
       credentials: {
         #disable-next-line BCP037

--- a/options-infra/modules/apim/advanced/types.bicep
+++ b/options-infra/modules/apim/advanced/types.bicep
@@ -51,6 +51,9 @@ type foundryInstanceType = {
 
   @description('Weight for load balancing within the same priority tier')
   weight: int?
+
+  @description('Whether this "instance" is actually another APIM gateway that already follows our per-model-gateway convention (passthrough at `/inference/openai/*`). When true, the backend URL becomes `{endpoint}inference/openai` regardless of model format, and circuit-breaker isolation operates per (downstream-APIM, model) pair. Useful for chaining: a regional APIM can front several other APIMs that each front different Foundry accounts.')
+  isApim: bool?
 }
 
 // -- Model Quota (per-model TPM and PTU allocation) ---------------------------

--- a/options-infra/modules/apim/ai-gateway-internal.bicep
+++ b/options-infra/modules/apim/ai-gateway-internal.bicep
@@ -1,3 +1,9 @@
+// _DEPRECATED: use modules/apim/per-model-gateway.bicep instead. This legacy
+// orchestrator implements the older "single backend pool + static-models inline"
+// pattern. per-model-gateway.bicep covers the same SKUs / networking variants
+// (public, Internal VNet, External+PE, Premium custom domain) plus per-(instance,
+// model) backends with smart routing and dynamic discovery.
+
 import { aiServiceConfigType } from 'v2/inference-api.bicep'
 import { ModelType } from '../ai/connection-apim-gateway.bicep'
 import { subscriptionType } from 'v2/apim.bicep'

--- a/options-infra/modules/apim/ai-gateway-pe.bicep
+++ b/options-infra/modules/apim/ai-gateway-pe.bicep
@@ -1,3 +1,9 @@
+// _DEPRECATED: use modules/apim/per-model-gateway.bicep instead. This legacy
+// orchestrator implements the older "single backend pool + static-models inline"
+// pattern. per-model-gateway.bicep covers the same SKUs / networking variants
+// (public, Internal VNet, External+PE, Premium custom domain) plus per-(instance,
+// model) backends with smart routing and dynamic discovery.
+
 import { aiServiceConfigType } from 'v2/inference-api.bicep'
 import { ModelType } from '../ai/connection-apim-gateway.bicep'
 import { subscriptionType } from 'v2/apim.bicep'

--- a/options-infra/modules/apim/ai-gateway-premium.bicep
+++ b/options-infra/modules/apim/ai-gateway-premium.bicep
@@ -1,3 +1,9 @@
+// _DEPRECATED: use modules/apim/per-model-gateway.bicep instead. This legacy
+// orchestrator implements the older "single backend pool + static-models inline"
+// pattern. per-model-gateway.bicep covers the same SKUs / networking variants
+// (public, Internal VNet, External+PE, Premium custom domain) plus per-(instance,
+// model) backends with smart routing and dynamic discovery.
+
 import { aiServiceConfigType } from 'v2/inference-api.bicep'
 import { ModelType } from '../ai/connection-apim-gateway.bicep'
 import { subscriptionType, hostnameConfigurationType } from 'v2/apim.bicep'

--- a/options-infra/modules/apim/ai-gateway.bicep
+++ b/options-infra/modules/apim/ai-gateway.bicep
@@ -1,3 +1,9 @@
+// _DEPRECATED: use modules/apim/per-model-gateway.bicep instead. This legacy
+// orchestrator implements the older "single backend pool + static-models inline"
+// pattern. per-model-gateway.bicep covers the same SKUs / networking variants
+// (public, Internal VNet, External+PE, Premium custom domain) plus per-(instance,
+// model) backends with smart routing and dynamic discovery.
+
 import { aiServiceConfigType } from 'v2/inference-api.bicep'
 import { ModelType } from '../ai/connection-apim-gateway.bicep'
 import { subscriptionType } from 'v2/apim.bicep'

--- a/options-infra/modules/apim/per-model-gateway.bicep
+++ b/options-infra/modules/apim/per-model-gateway.bicep
@@ -47,6 +47,9 @@ param deploySpecApi bool = true
 @description('URL path for the spec-backed AzureOpenAI API. Must not collide with the passthrough path (`inference/openai`). The AzureOpenAI inference-api module appends `/openai`, so a value of `openai` exposes the API at `…/openai/openai/…` — use `azure` (default) for `…/azure/openai/…`.')
 param specApiPath string = 'azure'
 
+@description('Tenant IDs whose Entra ID tokens are accepted as inbound auth. When non-empty, both inference APIs inject a `<validate-jwt>` block that requires `aud=https://cognitiveservices.azure.com` and lists one issuer per tenant (both v1 `sts.windows.net/{tid}/` and v2 `login.microsoftonline.com/{tid}/v2.0`). Empty (default) = no inbound JWT validation — backward-compatible.')
+param acceptedTenantIds string[] = []
+
 param logAnalyticsWorkspaceResourceId string
 param appInsightsInstrumentationKey string = ''
 param appInsightsResourceId string = ''
@@ -97,6 +100,21 @@ param vnetResourceIdsForDnsLink string[] = []
 // below so the discovery operations (added via `existing` references) can find
 // it deterministically.
 var passthroughApiName = 'inference-api'
+
+// -- Multi-tenant inbound JWT validation -------------------------------------
+// Replaces the `{JWT_VALIDATION}` token in policy-per-model.xml. When the
+// caller passes no tenants we emit a comment so the policy stays open (current
+// behaviour). Each accepted tenant contributes BOTH the v1 (`sts.windows.net`)
+// and v2 (`login.microsoftonline.com/.../v2.0`) issuer URLs since AAD tokens
+// can carry either depending on how the caller acquired them.
+var issuersXml = empty(acceptedTenantIds)
+  ? ''
+  : join(map(acceptedTenantIds, tid => '<issuer>https://sts.windows.net/${tid}/</issuer><issuer>https://login.microsoftonline.com/${tid}/v2.0</issuer>'), '')
+var jwtValidationXml = empty(acceptedTenantIds)
+  ? '<!-- multi-tenant JWT validation disabled (acceptedTenantIds is empty) -->'
+  : '<validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized"><openid-config url="https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration" /><audiences><audience>https://cognitiveservices.azure.com</audience><audience>https://cognitiveservices.azure.com/</audience></audiences><issuers>${issuersXml}</issuers></validate-jwt>'
+
+var policyPerModelXml = replace(loadTextContent('policy-per-model.xml'), '{JWT_VALIDATION}', jwtValidationXml)
 
 // -- Custom domain validation + synthesis -----------------------------------
 // When customDomain is set, every dependency (cert URI + KV name + UAMI) must
@@ -272,7 +290,7 @@ module inferenceApi 'v2/inference-api.bicep' = {
   name: 'inference-api-deployment'
   dependsOn: [foundryBackends, callerIdentityFragment, perModelRoutingFragment]
   params: {
-    policyXml: loadTextContent('policy-per-model.xml')
+    policyXml: policyPerModelXml
     apiManagementName: apimService.outputs.name
     apimLoggerId: apimService.outputs.loggerId
     aiServicesConfig: []
@@ -300,7 +318,7 @@ module inferenceApiSpec 'v2/inference-api.bicep' = if (deploySpecApi) {
   name: 'inference-api-spec-deployment'
   dependsOn: [inferenceApi, foundryBackends, callerIdentityFragment, perModelRoutingFragment]
   params: {
-    policyXml: loadTextContent('policy-per-model.xml')
+    policyXml: policyPerModelXml
     apiManagementName: apimService.outputs.name
     apimLoggerId: apimService.outputs.loggerId
     aiServicesConfig: []

--- a/options-infra/modules/apim/per-model-gateway.bicep
+++ b/options-infra/modules/apim/per-model-gateway.bicep
@@ -15,7 +15,7 @@
 
 import { foundryInstanceType } from 'advanced/types.bicep'
 import { ModelType } from '../ai/connection-apim-gateway.bicep'
-import { subscriptionType } from 'v2/apim.bicep'
+import { subscriptionType, hostnameConfigurationType } from 'v2/apim.bicep'
 
 // -- Parameters ---------------------------------------------------------------
 param location string = resourceGroup().location
@@ -38,7 +38,7 @@ param staticModels ModelType[] = []
 param gatewayAuthenticationType string = 'ProjectManagedIdentity'
 
 @description('APIM SKU.')
-@allowed(['Basicv2', 'Standardv2', 'Premiumv2'])
+@allowed(['Consumption', 'Developer', 'Basic', 'Basicv2', 'Standard', 'Standardv2', 'Premium', 'Premiumv2'])
 param apimSku string = 'Basicv2'
 
 @description('Also deploy a spec-backed AzureOpenAI inference API (with per-operation definitions, model-discovery endpoints, and the APIM test console) alongside the Foundry-facing passthrough. Both APIs share the same per-model routing fragment, so they hit the same backend pools.')
@@ -51,11 +51,90 @@ param logAnalyticsWorkspaceResourceId string
 param appInsightsInstrumentationKey string = ''
 param appInsightsResourceId string = ''
 
+// -- Networking / SKU-variant params (all optional, pass-through to v2/apim.bicep) -
+// These let per-model-gateway.bicep host the public-only, internal-VNET, External-VNET+PE,
+// custom-domain, and Premium variants without forking the orchestrator.
+
+@description('VNet integration mode for the APIM service. None (default) = public, External = injected with internet ingress, Internal = injected with no public endpoint.')
+@allowed(['None', 'External', 'Internal'])
+param virtualNetworkType string = 'None'
+
+@description('Subnet resource ID for the APIM injection. Required when virtualNetworkType is External or Internal.')
+param subnetResourceId string?
+
+@description('Public network access on the APIM service. Leave Enabled for public deployments. When opting into PE attachment (peSubnetResourceId), pass Disabled to trigger the post-PE flip step.')
+@allowed(['Enabled', 'Disabled'])
+param publicNetworkAccess string = 'Enabled'
+
+@description('Subnet resource ID hosting the APIM private endpoint. When non-empty, the module attaches a private endpoint (with the privatelink.azure-api.net DNS zone) and — if publicNetworkAccess=Disabled — runs a follow-up APIM deploy to flip public access off. Service-creation itself uses publicNetworkAccess=null in that case (Azure blocks setting Disabled on initial create).')
+param peSubnetResourceId string = ''
+
+@description('Custom hostname configurations for the APIM gateway (e.g. proxy custom domain backed by a Key Vault cert). Empty = use the default *.azure-api.net hostname.')
+param hostnameConfigurations hostnameConfigurationType[] = []
+
+@description('APIM managed-identity mode. UserAssigned is required when hostnameConfigurations reference a Key Vault cert.')
+@allowed(['SystemAssigned', 'UserAssigned', 'SystemAssigned, UserAssigned'])
+param apimManagedIdentityType string = 'SystemAssigned'
+
+@description('User-assigned managed identity resource ID. Required when apimManagedIdentityType includes UserAssigned (KV-cert custom domain).')
+param apimUserAssignedManagedIdentityResourceId string?
+
+// -- Custom domain (Internal VNet variants like Premium) --------------------
+@description('Custom apex domain (e.g. "cloud.example.com"). When set, the gateway is exposed at https://apim.{customDomain}/… via a Key Vault-sourced certificate. Requires keyVaultName + certificateKeyVaultUri + a UAMI with KV Certificate User + Secrets User. Leave empty to use the default *.azure-api.net hostname.')
+param customDomain string = ''
+
+@description('Key Vault name holding the custom-domain certificate. Required when customDomain is set — the gateway grants its UAMI Certificate User + Secrets User on this vault.')
+param keyVaultName string = ''
+
+@description('Key Vault secret URI of the custom-domain certificate (e.g. https://kv-xxx.vault.azure.net/secrets/customdomaincert). Required when customDomain is set.')
+param certificateKeyVaultUri string = ''
+
+@description('Extra VNet resource IDs to link to the privatelink.azure-api.net (and customDomain) DNS zones — useful when APIM lives in its own VNet but callers live in a peered one. Only applied when virtualNetworkType=Internal.')
+param vnetResourceIdsForDnsLink string[] = []
+
 // -- Constants ----------------------------------------------------------------
 // Passthrough API resource name. Must match what we pass to the v2 module
 // below so the discovery operations (added via `existing` references) can find
 // it deterministically.
 var passthroughApiName = 'inference-api'
+
+// -- Custom domain validation + synthesis -----------------------------------
+// When customDomain is set, every dependency (cert URI + KV name + UAMI) must
+// also be set — fail fast with a clear error so the caller can't silently
+// deploy a half-configured custom-domain gateway.
+var customDomainEnabled = !empty(customDomain)
+var customDomainValid = customDomainEnabled && (empty(certificateKeyVaultUri) || empty(keyVaultName) || empty(apimUserAssignedManagedIdentityResourceId))
+  ? fail('customDomain requires certificateKeyVaultUri, keyVaultName, and apimUserAssignedManagedIdentityResourceId to all be set.')
+  : true
+
+// PremiumV2 only supports 'Proxy' and 'DeveloperPortal' hostname types for
+// custom domains — Proxy is what gateway clients hit, so we register that one.
+// Callers can still override by passing hostnameConfigurations explicitly.
+var synthesizedHostnameConfigurations hostnameConfigurationType[] = customDomainEnabled
+  ? [
+      {
+        type: 'Proxy'
+        hostName: 'apim.${customDomain}'
+        certificateSource: 'KeyVault'
+        keyVaultId: certificateKeyVaultUri
+      }
+    ]
+  : []
+
+var effectiveHostnameConfigurations = !empty(hostnameConfigurations)
+  ? hostnameConfigurations
+  : synthesizedHostnameConfigurations
+
+// Internal VNet variant: derive the gateway's own VNet (parent of subnetResourceId)
+// so the apim-dns module can link the *.azure-api.net (and customDomain) zones
+// to it. Other variants ignore these.
+var internalVnetMode = virtualNetworkType == 'Internal' && !empty(subnetResourceId)
+var subnetIdParts = internalVnetMode ? split(subnetResourceId!, '/') : []
+var subnetNameForDns = internalVnetMode ? last(subnetIdParts) : ''
+var apimOwnVnetResourceId = internalVnetMode
+  ? substring(subnetResourceId!, 0, length(subnetResourceId!) - length('/subnets/${subnetNameForDns}'))
+  : ''
+var dnsLinkVnetResourceIds = internalVnetMode ? union(vnetResourceIdsForDnsLink, [apimOwnVnetResourceId]) : []
 
 // -- Derived ------------------------------------------------------------------
 var connectionPerProject = !empty(aiFoundryProjectNames)
@@ -74,6 +153,15 @@ var subscriptions subscriptionType[] = connectionPerProject
 // ============================================================================
 // -- APIM service
 // ============================================================================
+// When peSubnetResourceId is set AND the caller wants publicNetworkAccess=Disabled
+// (private-only), Azure rejects setting Disabled on initial creation
+// ("Blocking all public network access ... is not enabled during service creation").
+// We mirror the legacy ai-gateway-pe.bicep dance: create with the field null,
+// attach the PE, then re-deploy with publicNetworkAccess=Disabled.
+var attachingPrivateEndpoint = !empty(peSubnetResourceId)
+var deferPublicAccessFlip = attachingPrivateEndpoint && publicNetworkAccess == 'Disabled'
+var initialPublicNetworkAccess = deferPublicAccessFlip ? null : publicNetworkAccess
+
 module apimService 'v2/apim.bicep' = {
   name: 'apim-deployment'
   params: {
@@ -85,6 +173,53 @@ module apimService 'v2/apim.bicep' = {
     appInsightsInstrumentationKey: appInsightsInstrumentationKey
     appInsightsId: appInsightsResourceId
     apimSubscriptionsConfig: subscriptions
+    virtualNetworkType: virtualNetworkType
+    subnetResourceId: subnetResourceId
+    #disable-next-line BCP036
+    publicNetworkAccess: initialPublicNetworkAccess
+    hostnameConfigurations: effectiveHostnameConfigurations
+    apimManagedIdentityType: apimManagedIdentityType
+    apimUserAssignedManagedIdentityResourceId: apimUserAssignedManagedIdentityResourceId
+  }
+}
+
+// ============================================================================
+// -- Internal-VNet DNS linking (privatelink.azure-api.net + custom domain)
+// ============================================================================
+// Required when virtualNetworkType=Internal: APIM has no public endpoint, so
+// callers in the VNet resolve `*.azure-api.net` via a private DNS zone linked
+// to the gateway's VNet (and any peered VNets the caller passes in).
+module apimDns 'apim-dns.bicep' = if (internalVnetMode) {
+  name: 'apim-dns-configuration'
+  params: {
+    tags: tags
+    apimIpAddress: apimService.outputs.apimPrivateIp
+    vnetResourceIds: dnsLinkVnetResourceIds
+    apimName: apimService.outputs.name
+  }
+}
+
+module apimCustomDns 'apim-dns.bicep' = if (internalVnetMode && customDomainEnabled) {
+  name: 'apim-custom-dns-configuration'
+  params: {
+    tags: tags
+    apimIpAddress: apimService.outputs.apimPrivateIp
+    vnetResourceIds: dnsLinkVnetResourceIds
+    apimName: 'apim'
+    zoneName: customDomain
+  }
+}
+
+// ============================================================================
+// -- APIM private endpoint (opt-in via peSubnetResourceId)
+// ============================================================================
+module apimPrivateEndpoint 'apim-pe.bicep' = if (attachingPrivateEndpoint) {
+  name: 'apim-pe-deployment'
+  params: {
+    tags: tags
+    location: location
+    apimName: apimService.outputs.name
+    peSubnetResourceId: peSubnetResourceId
   }
 }
 
@@ -270,10 +405,93 @@ module aiGatewayProjectConnectionStatic '../ai/connection-apim-gateway.bicep' = 
   }
 ]
 
+// ============================================================================
+// -- Post-PE: flip publicNetworkAccess to Disabled
+// ============================================================================
+// Azure rejects publicNetworkAccess=Disabled on the initial APIM create when a
+// private endpoint is being attached. We deferred the flag and now re-deploy
+// the same APIM resource with it Disabled — after every child resource has
+// been created (and so could still be reached over the public endpoint).
+// This is intentionally a no-op when peSubnetResourceId is empty OR when the
+// caller wants the gateway to keep public access (publicNetworkAccess=Enabled).
+module apimServiceUpdate 'v2/apim.bicep' = if (deferPublicAccessFlip) {
+  name: 'apim-update-deployment'
+  dependsOn: [
+    apimPrivateEndpoint
+    callerIdentityFragment
+    perModelRoutingFragment
+    foundryBackends
+    inferenceApi
+    inferenceApiSpec
+    passthroughDiscovery
+    specApiDiscovery
+    aiGatewayConnectionStatic
+    aiGatewayProjectConnectionStatic
+  ]
+  params: {
+    location: location
+    tags: tags
+    resourceSuffix: resourceToken
+    apimSku: apimSku
+    lawId: logAnalyticsWorkspaceResourceId
+    appInsightsInstrumentationKey: appInsightsInstrumentationKey
+    appInsightsId: appInsightsResourceId
+    apimSubscriptionsConfig: subscriptions
+    virtualNetworkType: virtualNetworkType
+    subnetResourceId: subnetResourceId
+    publicNetworkAccess: 'Disabled'
+    hostnameConfigurations: effectiveHostnameConfigurations
+    apimManagedIdentityType: apimManagedIdentityType
+    apimUserAssignedManagedIdentityResourceId: apimUserAssignedManagedIdentityResourceId
+  }
+}
+
+// ============================================================================
+// -- Custom-domain hostname update (Internal VNet variants)
+// ============================================================================
+// Mirrors ai-gateway-premium.bicep's `apim_update` step: a lightweight
+// re-deploy that only touches the hostname configurations (and grants the
+// APIM UAMI Certificate User + Secrets User on the KV holding the cert), so
+// we don't have to re-deploy the full APIM resource with all its APIs.
+// Gated on customDomainEnabled — irrelevant for public / PE variants whose
+// custom hostnames (if any) are applied during the initial create.
+module apimHostnameUpdate 'apim-hostname-update.bicep' = if (customDomainEnabled && internalVnetMode) {
+  name: 'apim-hostname-update-deployment'
+  dependsOn: [
+    apimDns
+    apimCustomDns
+    callerIdentityFragment
+    perModelRoutingFragment
+    foundryBackends
+    inferenceApi
+    inferenceApiSpec
+    passthroughDiscovery
+    specApiDiscovery
+    aiGatewayConnectionStatic
+    aiGatewayProjectConnectionStatic
+  ]
+  params: {
+    tags: tags
+    location: location
+    resourceSuffix: resourceToken
+    apimSku: apimSku
+    virtualNetworkType: virtualNetworkType
+    subnetResourceId: subnetResourceId
+    #disable-next-line BCP036
+    publicNetworkAccess: null
+    apimUserAssignedManagedIdentityResourceId: apimUserAssignedManagedIdentityResourceId
+    apimManagedIdentityType: apimManagedIdentityType
+    apimPrincipalId: apimService.outputs.principalId
+    hostnameConfigurations: effectiveHostnameConfigurations
+    keyVaultName: keyVaultName
+  }
+}
+
 // -- Outputs ------------------------------------------------------------------
 output apimResourceId string = apimService.outputs.id
 output apimName string = apimService.outputs.name
 output apimPrincipalId string = apimService.outputs.principalId
 output apimGatewayUrl string = apimService.outputs.gatewayUrl
+output apimAppInsightsLoggerId string = apimService.outputs.loggerId
 output backendNames array = foundryBackends.outputs.backendNames
 output poolNames array = foundryBackends.outputs.poolNames

--- a/options-infra/modules/apim/policy-per-model.xml
+++ b/options-infra/modules/apim/policy-per-model.xml
@@ -2,6 +2,14 @@
     <inbound>
         <base />
 
+        <!-- ================================================================ -->
+        <!-- Optional: multi-tenant inbound JWT validation                    -->
+        <!-- Replaced by per-model-gateway.bicep with a `<validate-jwt>` block -->
+        <!-- listing one issuer per accepted tenant, or a comment when no     -->
+        <!-- tenants are configured (backward-compatible default).            -->
+        <!-- ================================================================ -->
+        {JWT_VALIDATION}
+
         <!-- Caller identity: x-caller-name, x-caller-id, x-caller-foundry, x-caller-project -->
         <include-fragment fragment-id="caller-identity" />
 

--- a/options-infra/scripts/preprovision-list-foundry-models.ps1
+++ b/options-infra/scripts/preprovision-list-foundry-models.ps1
@@ -107,6 +107,69 @@ function Get-FoundryInstance {
   }
 }
 
+# Process a chained APIM that already follows our per-model-gateway convention
+# (passthrough at `/inference/openai/*` + static-discovery operations). Identified
+# by its gateway URL — no ARM resource id needed, so this works across tenants
+# where the developer can hit the endpoint but doesn't have ARM perms.
+function Get-ApimInstance {
+  param([Parameter(Mandatory)][string]$Url)
+
+  # Normalise to scheme://host[:port] (strip any path the caller appended).
+  if ($Url -notmatch '^[a-z]+://[^/]+') {
+    throw "Malformed APIM URL (expected https://<host>[/...]): $Url"
+  }
+  $base = $Matches[0]
+  $host = ($base -split '/')[2]
+
+  # Short instance name from the first hostname label (keeps backend names readable).
+  $name = ($host -split '\.')[0]
+  if (-not $name) { $name = ($host -replace '[^A-Za-z0-9]', '-').Trim('-') }
+
+  Write-Step "🔗 $name — chained APIM"
+  Write-Field '🌐' 'Gateway URL' $base
+
+  $token = az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken -o tsv 2>$null
+  if ($LASTEXITCODE -ne 0 -or -not $token) {
+    throw 'Failed to acquire an AAD token for cognitiveservices.azure.com.'
+  }
+
+  $listingUrl = "$base/inference/openai/deployments"
+  try {
+    $listing = Invoke-RestMethod -Uri $listingUrl -Headers @{ Authorization = "Bearer $token" } -Method Get
+  } catch {
+    throw "Downstream APIM discovery call failed: $listingUrl  ($($_.Exception.Message))"
+  }
+
+  $deployments = @()
+  if ($listing.value) {
+    $deployments = @($listing.value | ForEach-Object {
+      [PSCustomObject]@{
+        modelName    = $_.name
+        modelVersion = $_.properties.model.version
+        modelFormat  = if ($_.properties.model.format) { $_.properties.model.format } else { 'OpenAI' }
+      }
+    })
+    foreach ($d in $listing.value) {
+      Write-Host ("   {0,-30}  {1,-22}  {2,-10}  {3}" -f $d.name, $d.properties.model.name, $d.properties.model.version, $d.properties.model.format)
+    }
+  } else {
+    Write-Warn 'Downstream APIM exposed no deployments.'
+  }
+
+  return [PSCustomObject]@{
+    name        = "apim-$name"
+    # resourceId carries the URL — keeps foundryInstanceType.resourceId a non-empty
+    # string and acts as a unique key. main.bicep skips ARM operations for isApim=true.
+    resourceId  = $base
+    endpoint    = "$base/"
+    location    = 'external'
+    isPtu       = $false
+    isApim      = $true
+    deployments = $deployments
+    _depCount   = $deployments.Count
+  }
+}
+
 Write-Banner 'Foundry instance discovery'
 
 $rawIds    = Get-AzdEnv 'EXISTING_FOUNDRY_RESOURCE_IDS'
@@ -120,31 +183,43 @@ if (-not $rawIds) {
   if ($rawIds) { $sourceVar = 'OPENAI_RESOURCE_ID (fallback)' }
 }
 
-if (-not $rawIds) {
-  Write-Skip 'No existing Foundry instances configured.'
+$apimUrls = Get-AzdEnv 'EXISTING_APIM_URLS'
+
+if (-not $rawIds -and -not $apimUrls) {
+  Write-Skip 'No existing Foundry or APIM instances configured.'
   Write-Dim '   Set one of:'
   Write-Dim '     • EXISTING_FOUNDRY_RESOURCE_IDS (comma-separated, multi-instance)'
   Write-Dim '     • EXISTING_FOUNDRY_RESOURCE_ID  (single instance)'
   Write-Dim '     • OPENAI_RESOURCE_ID            (AI Gateway sample fallback)'
+  Write-Dim '     • EXISTING_APIM_URLS            (comma-separated gateway URLs — chained per-model-gateway APIMs)'
   azd env set FOUNDRY_INSTANCES_JSON '[]' | Out-Null
   Write-Host ''
   Write-Ok "Wrote FOUNDRY_INSTANCES_JSON=[] (deployment will fail with a clear 'no instances' message)"
   return
 }
 
-Write-Field '📥' 'Source' $sourceVar
+if ($rawIds)   { Write-Field '📥' 'Foundry source' $sourceVar }
+if ($apimUrls) { Write-Field '📥' 'APIM source'    'EXISTING_APIM_URLS' }
 
-$ids = $rawIds.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
 $instances = @()
 $totalDeployments = 0
-foreach ($rid in $ids) {
-  $inst = Get-FoundryInstance -ResourceId $rid
-  $totalDeployments += $inst._depCount
-  $instances += $inst
+if ($rawIds) {
+  foreach ($rid in ($rawIds.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+    $inst = Get-FoundryInstance -ResourceId $rid
+    $totalDeployments += $inst._depCount
+    $instances += $inst
+  }
+}
+if ($apimUrls) {
+  foreach ($url in ($apimUrls.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+    $inst = Get-ApimInstance -Url $url
+    $totalDeployments += $inst._depCount
+    $instances += $inst
+  }
 }
 
 if ($instances.Count -eq 0) {
-  Write-Err 'EXISTING_FOUNDRY_RESOURCE_IDS contained no valid ids.'
+  Write-Err 'No valid Foundry or APIM ids found in configured env vars.'
   exit 1
 }
 

--- a/options-infra/scripts/preprovision-list-foundry-models.sh
+++ b/options-infra/scripts/preprovision-list-foundry-models.sh
@@ -147,6 +147,121 @@ process_instance() {
   instance_count=$((instance_count + 1))
 }
 
+# Process an EXISTING APIM gateway that already follows our per-model-gateway
+# convention (passthrough at `/inference/openai/*` + the static-discovery ops).
+# Identified by its gateway URL — no ARM resource id needed, so this works
+# across tenants where the developer can hit the endpoint but doesn't have ARM
+# perms (or doesn't have `az login` for that tenant in their shell).
+#
+# We treat each model exposed by the downstream as an (instance, model) pair
+# backed by `{apim-gateway-url}/inference/openai`. The upstream caller-side
+# gateway then load-balances + circuit-breaks across chained APIMs the same
+# way it does across Foundries.
+#
+# Auth: the discovery call uses the developer's `az` AAD token (audience
+# cognitiveservices.azure.com). The downstream APIM's validate-jwt must accept
+# the developer's tenant. At runtime the upstream APIM's MI presents its own
+# bearer (same audience); the downstream must accept the upstream APIM's MI
+# tenant too — typically the same tenant in a single-org chain.
+process_apim() {
+  url=$1
+
+  # Normalise: strip any path/query so `url` is just `scheme://host[:port]`.
+  base=$(printf '%s' "$url" | awk -F/ '{print $1"//"$3}')
+  host=$(printf '%s' "$base" | awk -F/ '{print $3}')
+
+  if [ -z "$host" ]; then
+    err "Malformed APIM URL (expected https://<host>[/...]): $url"
+    exit 1
+  fi
+
+  # Derive a short, deterministic instance name from the host so the upstream
+  # backend names (`{instance}-{model-clean}-backend`) stay readable. Default
+  # to the first hostname label, fall back to a hash if it's empty.
+  name=$(printf '%s' "$host" | awk -F. '{print $1}')
+  [ -z "$name" ] && name=$(printf '%s' "$host" | tr -c '[:alnum:]' '-' | sed 's/-\+/-/g;s/^-//;s/-$//')
+
+  step "🔗 ${name} — chained APIM"
+  field "🌐" "Gateway URL" "$base"
+
+  # Fetch the downstream's static deployments listing. Uses the developer's
+  # AAD token; the downstream must accept this tenant in its `acceptedTenantIds`.
+  token=$(az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken -o tsv 2>/dev/null) || token=""
+  if [ -z "$token" ]; then
+    err "Failed to acquire an AAD token for cognitiveservices.azure.com."
+    exit 1
+  fi
+
+  listing_url="${base}/inference/openai/deployments"
+  listing=$(curl -sS -H "Authorization: Bearer $token" "$listing_url" 2>/dev/null) || listing=""
+
+  if [ -z "$listing" ] || ! printf '%s' "$listing" | grep -q '"value"'; then
+    err "Downstream APIM discovery call failed: $listing_url"
+    [ -n "$listing" ] && printf '%s   response: %s%s\n' "$C_DIM" "$(printf '%s' "$listing" | head -c 200)" "$C_RESET" >&2
+    exit 1
+  fi
+
+  # Project the downstream's static `{ "value": [{ name, properties.model.{name,version,format} }] }`
+  # into our `foundryDeploymentType` shape.
+  deps_json=$(printf '%s' "$listing" | python3 -c '
+import json, sys
+src = json.load(sys.stdin).get("value", [])
+out = [
+    {
+        "modelName":    d["name"],
+        "modelVersion": d["properties"]["model"].get("version", ""),
+        "modelFormat":  d["properties"]["model"].get("format", "OpenAI"),
+    }
+    for d in src
+]
+print(json.dumps(out, separators=(",", ":")))
+' 2>/dev/null) || deps_json="[]"
+
+  dep_count=$(printf '%s' "$deps_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+
+  if [ "$dep_count" -gt 0 ]; then
+    printf '%s' "$listing" | python3 -c '
+import json, sys
+src = json.load(sys.stdin).get("value", [])
+rows = [("Name", "Model", "Version", "Format")]
+for d in src:
+    m = d["properties"]["model"]
+    rows.append((d["name"], m.get("name", ""), m.get("version", ""), m.get("format", "")))
+widths = [max(len(r[i]) for r in rows) for i in range(4)]
+for i, r in enumerate(rows):
+    line = "  ".join(c.ljust(widths[j]) for j, c in enumerate(r))
+    print("   " + line)
+    if i == 0:
+        print("   " + "  ".join("-" * widths[j] for j in range(4)))
+' 2>/dev/null
+  else
+    warn "Downstream APIM exposed no deployments."
+  fi
+
+  total_deployments=$((total_deployments + dep_count))
+
+  # Endpoint = gateway URL with trailing /. Bicep appends `inference/openai`
+  # for APIM-flagged instances (see multi-foundry-backends.bicep), so the
+  # backend URL becomes `{gateway}/inference/openai` regardless of model format.
+  gateway_url="${base}/"
+
+  # resourceId is intentionally the URL — keeps the foundryInstanceType shape
+  # consistent (string), works as a unique key for dedup, and we never use it
+  # for ARM operations on isApim=true entries (main.bicep skips role assignment
+  # for those).
+  # location: 'external' is a deliberate placeholder. We don't have ARM access,
+  # and the upstream gateway only uses location for backend descriptions.
+  instance_json=$(printf '{"name":"apim-%s","resourceId":"%s","endpoint":"%s","location":"%s","isPtu":false,"isApim":true,"deployments":%s}' \
+    "$name" "$base" "$gateway_url" "external" "$deps_json")
+
+  if [ -z "$instances_json" ]; then
+    instances_json="[$instance_json"
+  else
+    instances_json="$instances_json,$instance_json"
+  fi
+  instance_count=$((instance_count + 1))
+}
+
 banner "Foundry instance discovery"
 
 # --- resolve input list ------------------------------------------------------
@@ -163,19 +278,29 @@ if [ -z "$raw_ids" ]; then
   [ -n "$raw_ids" ] && source_var="OPENAI_RESOURCE_ID (fallback)"
 fi
 
-if [ -z "$raw_ids" ]; then
-  skip "No existing Foundry instances configured."
+# Chained-APIM gateways (optional; appended to the Foundry list). Identified
+# by URL (not ARM resource id) so cross-tenant chains work without ARM perms.
+apim_urls=$(get_env EXISTING_APIM_URLS)
+
+if [ -z "$raw_ids" ] && [ -z "$apim_urls" ]; then
+  skip "No existing Foundry or APIM instances configured."
   printf '%s   Set one of:%s\n' "$C_DIM" "$C_RESET"
   printf '%s     • EXISTING_FOUNDRY_RESOURCE_IDS (comma-separated, multi-instance)%s\n' "$C_DIM" "$C_RESET"
   printf '%s     • EXISTING_FOUNDRY_RESOURCE_ID  (single instance)%s\n'                  "$C_DIM" "$C_RESET"
   printf '%s     • OPENAI_RESOURCE_ID            (AI Gateway sample fallback)%s\n'       "$C_DIM" "$C_RESET"
+  printf '%s     • EXISTING_APIM_URLS            (comma-separated gateway URLs — chained per-model-gateway APIMs)%s\n' "$C_DIM" "$C_RESET"
   azd env set FOUNDRY_INSTANCES_JSON "[]" >/dev/null
   printf '\n'
   ok "Wrote FOUNDRY_INSTANCES_JSON=[] (deployment will fail with a clear 'no instances' message)"
   exit 0
 fi
 
-field "📥" "Source" "$source_var"
+if [ -n "$raw_ids" ]; then
+  field "📥" "Foundry source" "$source_var"
+fi
+if [ -n "$apim_urls" ]; then
+  field "📥" "APIM source" "EXISTING_APIM_URLS"
+fi
 
 # --- iterate -----------------------------------------------------------------
 instances_json=""
@@ -194,8 +319,22 @@ for rid in "$@"; do
   process_instance "$rid"
 done
 
+# Chained APIMs (optional, processed after Foundries so they appear after in the array).
+if [ -n "$apim_urls" ]; then
+  old_ifs=$IFS
+  IFS=','
+  # shellcheck disable=SC2086
+  set -- $apim_urls
+  IFS=$old_ifs
+  for url in "$@"; do
+    url=$(printf '%s' "$url" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ -z "$url" ] && continue
+    process_apim "$url"
+  done
+fi
+
 if [ "$instance_count" -eq 0 ]; then
-  err "EXISTING_FOUNDRY_RESOURCE_IDS contained no valid ids."
+  err "No valid Foundry or APIM entries found in configured env vars."
   exit 1
 fi
 


### PR DESCRIPTION
Builds on top of `karpikpl/ai-gateway-basic-per-model-backends` — migrates the per-model-gateway pattern from `ai-gateway-basic` to every other AI gateway sample that takes (or provisions) a Foundry account.

## What's in this PR

### Samples migrated to `modules/apim/per-model-gateway.bicep`

| Sample | Networking / SKU | Notes |
|---|---|---|
| `ai-gateway` | Public Basicv2 | Foundry side has VNet + PEs; APIM public |
| `ai-gateway-internal` | Developer + Internal VNet | One upstream PE per backing Foundry |
| `ai-gateway-pe` | Standardv2 + External VNet + APIM PE | Honours `APIM_PUBLIC_ENABLED` flag |
| `ai-gateway-pe-custom` | Same as -pe | Synthesises `foundryInstances` from its in-deployment OpenAI (no discovery hook) |
| `ai-gateway-premium` | Premiumv2 + Internal VNet | KV-cert custom domain, UAMI, peered-VNet DNS |

Each sample now:
1. Runs the `preprovision-list-foundry-models` hook (except pe-custom) → `FOUNDRY_INSTANCES_JSON` → `foundryInstances` param.
2. Creates one APIM backend per (instance, model) + one PAYG pool per model.
3. Routes via the shared `per-model-routing` policy fragment.
4. Fans `Cognitive Services User` role assignments + private endpoints across all backing instances.

### `per-model-gateway.bicep` additions (needed for the variants)

- `apimAppInsightsLoggerId` output (consumed by `mcp_apis` side-cars)
- Custom-domain knobs: `customDomain`, `keyVaultName`, `certificateKeyVaultUri`, `vnetResourceIdsForDnsLink`
- Internal-VNet DNS modules (`apim-dns` for `*.azure-api.net` + the custom-domain zone)
- `apim-hostname-update` follow-up step (gated on custom-domain + Internal VNet) so we don't re-deploy the full APIM
- Broadened `apimSku` allowed list (was v2-only; Developer/Premiumv2 needed)

### Legacy

`modules/apim/ai-gateway{,-internal,-pe,-premium}.bicep` got a `_DEPRECATED` banner pointing at `per-model-gateway.bicep`. Not deleted — defer to a follow-up after callers migrate.

### Docs

All 6 README files rewritten to describe the new contract + smart routing.

## Verification

- `az bicep build` + `az bicep lint` clean on all 6 `main.bicep` files.
- Live-tested against `apim-njnufpcjpafkq` (rg-ai-gateway-image, sub 0721e282) with 2 Foundry instances:
  - 58 backends + 26 pools created
  - Shared models routed to multi-instance pools (gpt-4.1-mini, gpt-5-mini, o3-mini → 2 members each)
  - Exclusive models routed correctly (gpt-4o → landing-zone only; model-router → hack-foundry only)
  - End-to-end `POST /inference/openai/deployments/{model}/chat/completions` returned HTTP 200 on all three; nonexistent model returned HTTP 500 as expected.

## Out of scope

`litellm-*` (different model wiring), `ai-gateway-quota` (already richer per-model + PTU), `ai-gateway-existing` / `openrouter` / `anthropic` (no external AI on the APIM path).